### PR TITLE
Fixes the community.tex section

### DIFF
--- a/sections/community.tex
+++ b/sections/community.tex
@@ -1,21 +1,18 @@
 \section{Community}
 \label{sec:community}
 
-\subsection{Participation}
-
 The \sunpy community follows an open development process, wherein everyone is welcome to contribute code, raise issues, and provide feedback.
 As detailed in \sunpy Code of Conduct, the community encourages everyone, including newcomers, to join this process, and strives to create an create an open, considerate, and respectful environment for all.
 As part of the open development process, the \sunpy community maintains many active daily communication channels.
 Users can connect with the community through mailing lists, on an open-source protocol for real-time chat called matrix.org, or by attending weekly telecons.
+
 The \sunpy community also fosters code development for newcomers and experienced programmers alike through tutorials, summer programs, and mentorship.
-\sunpy community members voluntarily organize tutorials at various conferences and workshops, including AAS Solar Physics Division meetings.
-The \sunpyproj also participates in two summer of code programs, which offer students stipends to write code for open-source projects, via the OpenAstronomy umbrella organization.
+The \sunpy community organizes tutorials at various conferences and workshops, including the AAS Solar Physics Division meetings.
+The \sunpyproj also participates in two summer of code programs, which offer students stipends to write code for open source projects, via the OpenAstronomy umbrella organization.
 Since 2013, 16 students contributed to SunPy through the Google Summer of Code (GSoC) program.
 Since 2011, 7 students contributed to SunPy through a similar program funded by the European Space Agency called The ESA Summer of Code in Space.
 Many \sunpy community members served as mentors for these students.
 
-In 2018, NumFOCUS, a 501(c)(3) public charity which collects and manages tax-deductible contributions for many open-source scientific software packages such as NumPy and AstroPy, gave GSoC student Vishnunarayan K. I. an award for exceptional contributions to the open source scientific software ecosystem for his efforts to update SunPy with a modern astronomical time system.
-
-As of the publication of this paper, the \sunpy community consists of 35 active developers, 111 contributors, and an average of approximately 200 commits to the code base on a monthly basis.
+As of the publication of this paper, the \sunpy community consists 113 contributors, and an average of approximately 200 commits to the code base on a monthly basis.
 The commit history for the entire project is openly available, as are statistics for the number and frequency of commits per developer.
-Each developer and contributor to the \sunpy project is recognized for their work by name on papers, posters, and release notes.
+Each developer and contributor to the \sunpy project is recognized for their work by authorship on papers, posters, and release notes.

--- a/sections/community.tex
+++ b/sections/community.tex
@@ -5,14 +5,8 @@ The \sunpy community follows an open development process, wherein everyone is we
 As detailed in \sunpy Code of Conduct, the community encourages everyone, including newcomers, to join this process, and strives to create an create an open, considerate, and respectful environment for all.
 As part of the open development process, the \sunpy community maintains many active daily communication channels.
 Users can connect with the community through mailing lists, on an open-source protocol for real-time chat called matrix.org, or by attending weekly telecons.
-
 The \sunpy community also fosters code development for newcomers and experienced programmers alike through tutorials, summer programs, and mentorship.
-The \sunpy community organizes tutorials at various conferences and workshops, including the AAS Solar Physics Division meetings.
-The \sunpyproj also participates in two summer of code programs, which offer students stipends to write code for open source projects, via the OpenAstronomy umbrella organization.
-Since 2013, 16 students contributed to SunPy through the Google Summer of Code (GSoC) program.
-Since 2011, 7 students contributed to SunPy through a similar program funded by the European Space Agency called The ESA Summer of Code in Space.
-Many \sunpy community members served as mentors for these students.
 
 As of the publication of this paper, the \sunpy community consists 113 contributors, and an average of approximately 200 commits to the code base on a monthly basis.
 The commit history for the entire project is openly available, as are statistics for the number and frequency of commits per developer.
-Each developer and contributor to the \sunpy project is recognized for their work by authorship on papers, posters, and release notes.
+Developers and contributors to the \sunpy project receive credit for their work by authorship on papers, posters, and release notes.


### PR DESCRIPTION
This PR addresses issue #32 by:

- Removing the number of active developers, since this term is poorly defined
- Removing the subsection entitled "Participation", since there was only one subsection, as recommended by @wtbarnes 
- Breaking the text into 3 paragraphs instead of 2
- Removing a duplicate sentence from the Support & Sustainability section
- Making minor additional changes for readability