### PR TITLE
Copyediting 1-introduction.tex

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -22,6 +22,9 @@
 \newcommand{\astropypkg}{\package{astropy}}
 
 \newcommand{\numpy}{NumPy\xspace}
+\newcommand{\scipy}{SciPy\xspace}
+\newcommand{\matplotlib}{matplotlib\xspace}
+\newcommand{\pandas}{pandas\xspace}
 
 \newcommand{\Map}{\sunpycode{Map}}
 \newcommand{\Timeseries}{\sunpycode{TimeSeries}}

--- a/sections/1-introduction.tex
+++ b/sections/1-introduction.tex
@@ -17,9 +17,9 @@ A common, version-controlled, open source platform that provides a standard inte
 The mission statement of the \sunpyproj is to facilitate and promote the use and development of several community-led, free, and open source\footnote{\url{https://opensource.org/osd}} data analysis software packages based on the scientific \python\footnote{\url{https://www.python.org/}} environment.
 To achieve this goal, the project develops and maintains a core package (\sunpypkg) and supports an ecosystem of affiliated packages (see Section \ref{sec:affil_package}) that provides additional functionality.
 
-The \sunpyproj was formally founded in March of 2014 to formalize the organization managing the already developing \sunpypkg package.
+The \sunpyproj was officially founded in March of 2014 to formalize the organization managing the already developing \sunpypkg package.
 The project selected the \python programming language to leverage the rich ecosystem of packages already available for general data analysis.
-These include \numpy for multi-dimensional array manipulation \citep{numpy}, \package{scipy} for scientific functions \citep{scipy}, \package{Matplotlib} for publication-quality 2D plotting \citep{matplotlib}, and \package{Pandas} for data structures and time series analysis \citep{pandas}.
+These include \numpy for multi-dimensional array manipulation \citep{numpy}, \scipy for scientific functions \citep{scipy}, \matplotlib for publication-quality 2D plotting \citep{matplotlib}, and \pandas for data structures and time series analysis \citep{pandas}.
 These core packages form the backbone for hundreds of thousands of additional \python packages.
 Of particular relevance to \sunpypkg is the \astropypkg package, which provides core functionality for the analysis of astrophysical data \citep{astropy2018}.
 


### PR DESCRIPTION
* Changed `scipy` to SciPy based on the way the [scipy website](https://www.scipy.org/) refers to their library.
* Changed `matplotlib` to matplotlib based on the way [Hunter+2007](https://doi.org/10.1109/MCSE.2007.55) refers to the library.
* Changed `pandas` to pandas based on the way [McKinney+2009](https://pdfs.semanticscholar.org/f6da/c1c52d3b07c993fe52513b8964f86e8fe381.pdf) refers to the library.