### PR TITLE
Some minor changes to the drms section

### DIFF
--- a/sections/9-affiliated.tex
+++ b/sections/9-affiliated.tex
@@ -22,8 +22,8 @@ The following sections provides short descriptions of the existing affiliated pa
 \label{sec:drms}
 
 The \package{drms} package provides functionality to access data hosted by the Joint Science Operations Center (JSOC).
-Operated by Stanford, it is the primary data center for the Solar Dynamics Observatory’s (SDO) Helioseismic and Magnetic Imager (HMI) and Atmospheric Imaging Assembly (AIA) instruments, the Solar and Heliospheric Observatory's (SoHO) Michelson Doppler Imager (MDI) instrument, the NASA Interface Region Imaging Spectrograph (IRIS) Explorer.
-DRMS stands for Data Record Management System, a pSQL database that contains metadata, as well as pointers to image data, for every image contained in the archive.
+Operated by Stanford, it is the primary data center for the Solar Dynamics Observatory’s (SDO) Helioseismic and Magnetic Imager (HMI) and Atmospheric Imaging Assembly (AIA) instruments, the Solar and Heliospheric Observatory's (SOHO) Michelson Doppler Imager (MDI) instrument, and the NASA Interface Region Imaging Spectrograph (IRIS) Explorer.
+DRMS stands for Data Record Management System. It is based on a PostgreSQL database that contains metadata, as well as pointers to image data, for every image contained in the archive.
 The \package{drms} package provides access to query the rich image metadata in the JSOC DRMS. It can also be used to submit tailored data export requests (e.g. movies and images in various formats) and download data files.
 The package is built on the HTTP/JSON interface provided by JSOC.
 


### PR DESCRIPTION
- The official abbreviation for Solar and Heliospheric Observatory is
  SOHO, not SoHO.
- The product name of the database is PostgreSQL, not pSQL.
- The DRMS is a system that manages a database, not the database itself.