### PR TITLE
Fix affiliations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ main.bbl
 main.blg
 main.dvi
 main.fls
+main.out
 authors.aux
 authors.fdb_latexmk
 authors.fls

--- a/aastex63.cls
+++ b/aastex63.cls
@@ -1,11 +1,10 @@
-%% 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% AASTeX62.cls                                  %%
-%% Jan 6, 2018                                   %%
-%% Copyright 2018 American Astronomical Society  %%
+%% AASTEX63.cls                                  %%
+%% July 8, 2019 (6:15pm)                         %%
+%% Copyright 2019 American Astronomical Society  %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\def\currversion{6.2}
+\def\currversion{6.3}
 
 %%
 %%    These files are distributed
@@ -81,8 +80,8 @@
 %%%     abstract        = "formatter for AAS journal submissions",
 %%%  }
 
-\ProvidesClass{aastex62}%%%
- [2017/10/16 Version 6.2/AAS markup document class]%
+\ProvidesClass{aastex63}%%%
+ [2019/06/03 Version 6.3/AAS markup document class]%
 {}
 \ClassInfo{aastex}{%
 ^^J
@@ -144,6 +143,7 @@ track changes, new `modern' style and much more, by Amy Hendrickson,%
 %      numberedappendix: Legacy command, will produce same results as lettered appendix, since we don't want more
 %                        than one `section 1' in article: will cause problems for cross referencing.
 
+%    anonymous: to not list authors/affiliations be listed
 
 \newif\ifmanu
 \newif\iftwelvepoint
@@ -173,6 +173,8 @@ track changes, new `modern' style and much more, by Amy Hendrickson,%
 
 %% left in from older version, in case it could be useful:
 
+
+
 \DeclareOption{twocolumn}{\twocolstyletrue\@two@coltrue\twelvepointfalse}
 
 %% default style
@@ -184,10 +186,7 @@ track changes, new `modern' style and much more, by Amy Hendrickson,%
  Thank-you!^^J^^J=================}\stop}
 
 \newif\if@two@col@app
-\DeclareOption{twocolappendix}{\typeout{^^J^^J The option^^J
-`twocolappendix' no
-longer works! onecolappendix is preferred,^^J
-and is the default.^^J^^J}\stop}%\@two@col@apptrue}
+\DeclareOption{twocolappendix}{\@two@col@apptrue}
 \DeclareOption{onecolappendix}{\@two@col@appfalse}%% this is default
 
 \newif\iflongauthor
@@ -253,6 +252,9 @@ access fonts for the \string\astro\space command
 
 \newif\iftrack
 \DeclareOption{trackchanges}{\global\tracktrue}
+
+\newif\ifanonymous
+\DeclareOption{anonymous}{\global\anonymoustrue}
 
 %% End AH Options
 
@@ -619,7 +621,8 @@ revtex4-1.cls^^J^^J}\stop
 
 %% running heads:
 \def\lefthead#1{\gdef\@versohead{#1}} \lefthead{\relax}
-\def\righthead#1{\gdef\@rectohead{#1}} \righthead{\relax}
+\def\righthead#1{\ifanonymous\gdef\@rectohead{\ \ Anonymous author(s)
+\hfill}\else\gdef\@rectohead{#1}\fi} \righthead{\relax}
 \let\shorttitle\lefthead
 \let\shortauthors\righthead
 
@@ -651,7 +654,7 @@ revtex4-1.cls^^J^^J}\stop
 \vspace*{-\headsep}\vspace*{\headheight}
 \footnotesize
 \noindent{\sc Draft version \today}\\[2pt]
-{\footnotesize Typeset using \LaTeX\ {\bf RNAAS} style in AASTeX62}
+{\footnotesize Typeset using \LaTeX\ {\bf RNAAS} style in AASTeX63}
 \par\vspace*{-\baselineskip}\vspace*{0.625in}
 \else
 \vbox to 0pt{\vskip-48pt\normalsize\rptloopnum=0\loop
@@ -669,7 +672,7 @@ revtex4-1.cls^^J^^J}\stop
 \raggedright
 {\sc Draft version \today}\\[2pt]
 {\footnotesize
-Typeset using \LaTeX\ {\bf modern} style in AASTeX62}
+Typeset using \LaTeX\ {\bf modern} style in AASTeX63}
 \vskip48pt
 }
 \else
@@ -678,7 +681,7 @@ Typeset using \LaTeX\ {\bf modern} style in AASTeX62}
 \vspace*{-\headsep}\vspace*{\headheight}
 \footnotesize
 \noindent{\sc Draft version \today}\\[2pt]
-{\footnotesize Typeset using \LaTeX\ {\bf preprint} style in AASTeX62}
+{\footnotesize Typeset using \LaTeX\ {\bf preprint} style in AASTeX63}
 \par\vspace*{-\baselineskip}\vspace*{0.625in}
 \else
 %%
@@ -686,7 +689,7 @@ Typeset using \LaTeX\ {\bf modern} style in AASTeX62}
 \vspace*{-\headsep}\vspace*{\headheight}
 \footnotesize
 {\footnotesize\textsc{\@journalinfo}}\par
-{\footnotesize Typeset using \LaTeX\ {\bf preprint2} style in AASTeX62}
+{\footnotesize Typeset using \LaTeX\ {\bf preprint2} style in AASTeX63}
 \par\vspace*{-\baselineskip}\vspace*{0.625in}
 \else
 %%
@@ -694,7 +697,7 @@ Typeset using \LaTeX\ {\bf modern} style in AASTeX62}
 \vspace*{-\headsep}\vspace*{\headheight}
 \footnotesize
 {\footnotesize\textsc{\@journalinfo}}\par
-{\footnotesize Typeset using \LaTeX\ {\bf twocolumn} style in AASTeX62}
+{\footnotesize Typeset using \LaTeX\ {\bf twocolumn} style in AASTeX63}
 \par\vspace*{-\baselineskip}\vspace*{0.625in}
 \else
 \ifmanu
@@ -702,14 +705,14 @@ Typeset using \LaTeX\ {\bf modern} style in AASTeX62}
 \footnotesize
 \noindent\textsc{\@journalinfo}\\[-8pt]
 {\footnotesize Typeset using \LaTeX\ {\bf manuscript} style in
-AASTeX62}
+AASTeX63}
 \par\vspace*{-\baselineskip}\vspace*{0.625in}
 \else
 %% Default
 \vspace*{-\headsep}\vspace*{\headheight}
 \footnotesize
 {\footnotesize\textsc{\@journalinfo}}\par
-{\footnotesize Typeset using \LaTeX\ default style in AASTeX62}%% default style
+{\footnotesize Typeset using \LaTeX\ default style in AASTeX63}%% default style
 \par\vspace*{-\baselineskip}\vspace*{0.625in}
 \fi\fi\fi\fi\fi
 %%
@@ -745,7 +748,9 @@ AASTeX62}
 \newcount\endfncount
 \long\def\tempfootnote#1{\global\advance\fncount by 1\relax%
 \expandafter\gdef\csname
-footnote\the\fncount\endcsname{\if@two@col\hsize=242pt\fi\relax#1}}
+footnote\the\fncount\endcsname{\if@two@col\hsize=.5\textwidth
+\advance\hsize by -18pt
+\fi\relax#1}}
 
 \long\def\abstracttempfootnote#1{\global\advance\fncount by 1\relax%
 \expandafter\gdef\csname absfootnote\the\fncount\endcsname{#1}}
@@ -754,8 +759,10 @@ footnote\the\fncount\endcsname{\if@two@col\hsize=242pt\fi\relax#1}}
 
 \long\def\ltx@foottext#1#2{%
  \begingroup
-  \expandafter\ltx@make@current@footnote\expandafter{\@mpfn}{#1}%
-\@footnotetext{#2}%
+\expandafter\ltx@make@current@footnote\expandafter{\@mpfn}{#1}%
+\@footnotetext{\vtop{\iftwocolstyle\hsize=.5\textwidth
+\advance\hsize-18pt
+\fi #2\vskip2pt}}% fixed for two col style, march 15, 2019
  \endgroup
 }%
 
@@ -780,10 +787,16 @@ footnote\the\fncount\endcsname{\if@two@col\hsize=242pt\fi\relax#1}}
  \let\@AF@join\@title@join
 }%
 
-\def\frontmatter@title@format{\ifrnaas
-\large\scshape\centering
-\else
-\normalsize\centering\fi}
+\def\frontmatter@title@format{
+%% No exception for rnaas, May, 2019
+%\ifrnaas
+%\large\scshape\centering
+%\else
+\normalsize
+%% added Mar 2019
+\bf\centering
+%\fi
+}
 
 \def\frontmatter@title@below{\vskip8pt}%
 
@@ -1043,7 +1056,7 @@ footnote\the\fncount\endcsname{\if@two@col\hsize=242pt\fi\relax#1}}
 
 \let\footnoterule\relax
 
-\def\@makefntext#1{\mbox{}\hspace*{3mm}\@makefnmark~#1}
+\def\@makefntext#1{\hsize=\columnwidth\mbox{}\hspace*{3mm}\@makefnmark~#1}
 
 
 %  ****************************************
@@ -1052,10 +1065,18 @@ footnote\the\fncount\endcsname{\if@two@col\hsize=242pt\fi\relax#1}}
 
 \setcounter{secnumdepth}{3}
 
+\newcount\tempsectnum
+
 \newif\if@firstsection \@firstsectiontrue
 
 \def\section{%
 \if@firstsection
+%% In case no collaboration is listed:
+\ifcollaborationon\else\let\doauthor\olddoauthor
+\let\allauthors=\oldallauthors
+\fi
+%\edef\currauthorlimit{\the\AuthorCollaborationLimit}
+%\collaboration{\currauthorlimit}{}
      \maketitle
 \global\@firstsectionfalse
      \setcounter{footnote}{\thefront@matter@foot@note}%
@@ -1074,6 +1095,9 @@ footnote\the\fncount\endcsname{\if@two@col\hsize=242pt\fi\relax#1}}
    \twocolumngrid
    \fi
 \fi
+\tempsectnum=\the\c@section
+\advance\tempsectnum by 1
+\xdef\cref@currentlabel{section \the\tempsectnum}
     \@startsection{section}{1}{\z@}{9pt plus 1pt minus
     1pt}{4pt}{\apjsecfont\center}} 
 
@@ -1159,8 +1183,49 @@ the#1\endcsname}
 \penalty \ApjSectionpenalty}
 
 
-\def\acknowledgments{\vskip 5.8mm plus 1mm minus 1mm}
-\let\acknowledgements=\acknowledgments                  % second spelling
+
+%% begin...end form, not as good as \acknowledgments...\par
+\newbox\ackbox
+\def\xacknowledgments{\vskip 5.8mm plus 1mm minus 1mm
+\vskip1sp
+\section*{Acknowledgments}
+\vskip4pt
+\global\setbox\ackbox=\vbox\bgroup
+}
+
+\def\xendacknowledgments{\egroup
+\ifanonymous
+\centerline{(Acknowledgements anonymized for review)}
+\else
+\copy\ackbox\fi}
+
+%% If anonymous option is used, a message instead of acknowledgments will appear.
+
+
+\long\def\xacknowledgments\par#1\par{\vskip 5.8mm plus 1mm minus 1mm
+\vskip1sp
+\vbox{
+\section*{Acknowledgments}
+\ifanonymous
+\centerline{(Acknowledgements anonymized for review)}
+\else
+\nobreak
+\vtop{#1}\fi}\vskip6pt}
+
+
+\long\def\yacknowledgments#1\par{\vskip 5.8mm plus 1mm minus 1mm
+\vskip1sp
+\vbox{
+\section*{Acknowledgments}
+\ifanonymous
+\centerline{(Acknowledgements anonymized for review)}
+\else
+\nobreak
+\vtop{#1}\fi}\vskip6pt}
+
+\def\acknowledgments{\futurelet\next\checkforblankline}
+\def\checkforblankline{\ifx\next\par \let\go\xacknowledgments \else
+\let\go\yacknowledgments\fi\go}
 
 
 %  ****************************************
@@ -1169,7 +1234,6 @@ the#1\endcsname}
 
 \newcounter{remember@figure@num}
 \newcounter{remember@table@num}
-
 
 % this was an environment earlier, which doesn't make sense since we don't
 % do \begin{appendix}...\end{appendix}. Changed to \appendix which is how it is used.
@@ -1180,11 +1244,20 @@ the#1\endcsname}
 \newif\ifappendixon
 \def\appendix{
 \global\appendixontrue
+\if@two@col  
 \onecolumngrid
-%\clearpage
+\noindent\mbox{}\vrule height 24pt width0pt\hfill{\apjsecfont APPENDIX}\hfill\mbox{}\par
+\vskip18pt
+   \if@two@col@app\global\@two@coltrue\twocolumngrid \fi
+   % above, we want onecolumngrid to be default. Only twocolumn is asked for in documentclass option
+\else
+\noindent\mbox{}\vrule height 24pt width0pt\hfill{\apjsecfont
+APPENDIX}\hfill\mbox{}\par 
+\vskip18pt
+    \if@two@col@app\global\@two@coltrue\twocolumngrid 
+         \fi\fi
 % \vrule used for extra space; otherwise revtex4-1 sometimes eats
 % away the last line before appendix
-        \noindent\mbox{}\vrule height 24pt width0pt\hfill{\apjsecfont APPENDIX}\hfill\mbox{}\par
         \nopagebreak\medskip\@nobreaktrue\def\ApjSectionpenalty{\@M}
         \@firstsectionfalse
           \setcounter{section}{0}
@@ -1205,15 +1278,19 @@ the#1\endcsname}
 %\setcounter{equation}{0}
           \def\thesection{\Alph{section}}
           \def\theequation{\hbox{\Alph{section}\arabic{equation}}}
-          \def\section{
-\@startsection {section}{1}{\z@} 
+          \def\section{\@startsection {section}{1}{\z@} 
             {10pt}{5pt}{\centering\scshape\apjsecfont}}
 \else
 % Do not use appendix numbers in the titles
           \def\ApjSectionMarkInTitle{\AppendixApjSectionMarkInTitle}
 \fi
+\ifappletter
+\let\savesection\section
+\def\section{\resetapptablenumbers\savesection}
+\fi
 }
 %
+
 
 %%
 
@@ -1251,7 +1328,7 @@ the#1\endcsname}
 \def\bibitem{\vskip\bibskip\savebibitem}
 \newdimen\bibindent
 \renewenvironment{thebibliography}[1]{\global\bibtrue
-\ifrnaas\newpage\fi%+++
+%%\ifrnaas\newpage\fi% Not wanted, March 2019
 \onecolumngrid
 \vspace{20pt}
 \goodbreak
@@ -1432,6 +1509,8 @@ the#1\endcsname}
 \def\tabcaption{\@ifnextchar[{\@xtabcaption}{\@tabcaption}}
 \def\@tabcaption#1{{\def\@captype{table}\caption{#1}}}
 \def\@xtabcaption[#1]#2{{\def\@captype{table}\caption{#2}}}
+
+%% redefined below
 \def\fnum@table{{\@eapj@cap@font \@eapj@tabname~\thetable}}
 
  \let\fnum@ptable=\fnum@table
@@ -1467,7 +1546,7 @@ the#1\endcsname}
 \else
 \font\foo=cmr10\fi
 %%
-\fontdimen2\foo=1.5pt 
+\fontdimen2\foo=3pt %% Changed from 1.5pt to 3pt, March12, 2019
 %%
 {\large \it Software: }
 #2
@@ -1478,6 +1557,10 @@ the#1\endcsname}
 \fontdimen2\foo=3.33333pt
 \fi
 }\egroup}
+
+
+
+
 
 \newcommand\object{\@testopt\@object{[}}%
 \def\@object[#1]#2{#2}%
@@ -1569,7 +1652,7 @@ the#1\endcsname}
 \newcommand\ubvr{\mbox{$U\!BV\!R$}}%% UBVR system 
 \newcommand\ub{\mbox{$U\!-\!B$}}%   % U-B 
 \newcommand\bv{\mbox{$B\!-\!V$}}%   % B-V 
-\renewcommand\vr{\mbox{$V\!-\!R$}}%   % V-R ++
+\renewcommand\vr{\mbox{$V\!-\!R$}}%   % V-R 
 \newcommand\ur{\mbox{$U\!-\!R$}}%   % U-R 
 
 %% need this change so that it works correctly in tables:
@@ -1646,18 +1729,18 @@ the#1\endcsname}
  \vrule\@height\dimen@\@depth\dimen@i\@width\dimen@ii\nobreak
  }%
 
-\newcommand\anchor[2]{#2}% 
-\renewcommand\url{\@dblarg\@url}% 
-\def\@url[#1]{\anchor{#1}}% 
+%\newcommand\anchor[2]{#2}% 
+%\renewcommand\url{\@dblarg\@url}% 
+%\def\@url[#1]{\anchor{#1}}% 
 
 \let\jnl@style=\rmfamily 
 \def\ref@jnl#1{{\jnl@style#1}}% 
 \newcommand\aj{\ref@jnl{AJ}}%        % Astronomical Journal 
 \newcommand\araa{\ref@jnl{ARA\&A}}%  % Annual Review of Astron and Astrophys 
-\renewcommand\apj{\ref@jnl{ApJ}}%    % Astrophysical Journal ++
+\renewcommand\apj{\ref@jnl{ApJ}}%    % Astrophysical Journal 
 \newcommand\apjl{\ref@jnl{ApJL}}     % Astrophysical Journal, Letters 
 \newcommand\apjs{\ref@jnl{ApJS}}%    % Astrophysical Journal, Supplement 
-\renewcommand\ao{\ref@jnl{ApOpt}}%   % Applied Optics ++
+\renewcommand\ao{\ref@jnl{ApOpt}}%   % Applied Optics 
 \newcommand\apss{\ref@jnl{Ap\&SS}}%  % Astrophysics and Space Science 
 \newcommand\aap{\ref@jnl{A\&A}}%     % Astronomy and Astrophysics 
 \newcommand\aapr{\ref@jnl{A\&A~Rv}}%  % Astronomy and Astrophysics Reviews 
@@ -1665,14 +1748,15 @@ the#1\endcsname}
 \newcommand\azh{\ref@jnl{AZh}}%       % Astronomicheskii Zhurnal 
 \newcommand\baas{\ref@jnl{BAAS}}%     % Bulletin of the AAS 
 \newcommand\icarus{\ref@jnl{Icarus}}% % Icarus
+\newcommand\jaavso{\ref@jnl{JAAVSO}}  % The Journal of the American Association of Variable Star Observers
 \newcommand\jrasc{\ref@jnl{JRASC}}%   % Journal of the RAS of Canada 
 \newcommand\memras{\ref@jnl{MmRAS}}%  % Memoirs of the RAS 
 \newcommand\mnras{\ref@jnl{MNRAS}}%   % Monthly Notices of the RAS 
-\renewcommand\pra{\ref@jnl{PhRvA}}% % Physical Review A: General Physics ++
-\renewcommand\prb{\ref@jnl{PhRvB}}% % Physical Review B: Solid State ++
-\renewcommand\prc{\ref@jnl{PhRvC}}% % Physical Review C ++
-\renewcommand\prd{\ref@jnl{PhRvD}}% % Physical Review D ++
-\renewcommand\pre{\ref@jnl{PhRvE}}% % Physical Review E ++
+\renewcommand\pra{\ref@jnl{PhRvA}}% % Physical Review A: General Physics 
+\renewcommand\prb{\ref@jnl{PhRvB}}% % Physical Review B: Solid State 
+\renewcommand\prc{\ref@jnl{PhRvC}}% % Physical Review C 
+\renewcommand\prd{\ref@jnl{PhRvD}}% % Physical Review D 
+\renewcommand\pre{\ref@jnl{PhRvE}}% % Physical Review E 
 \renewcommand\prl{\ref@jnl{PhRvL}}% % Physical Review Letters 
 \newcommand\pasp{\ref@jnl{PASP}}%     % Publications of the ASP 
 \newcommand\pasj{\ref@jnl{PASJ}}%     % Publications of the ASJ 
@@ -1727,14 +1811,16 @@ the#1\endcsname}
 
 \newcounter{table@save}
 
-\def\tablenum#1{%
-  \setcounter{table@save}{\the\c@table}
-  \gdef\use@tablenum{1}
-  \setcounter{table}{#1}\def\thetable{#1}\def\@currentlabel{#1}
-  %\def\label##1{\save@label{##1}}
+%% March 25, 2019
+%% Old v5.2 way, From Greg, This allows a number like 33N to be used
+%% for a table, and the cross-references will work correctly
+\newcommand\tablenum[1]{%
+ \def\thetable{#1}%
+ \xdef\@currentlabel{\thetable}
+\global\advance\c@table-1\relax
 }%
-\gdef\use@tablenum{0}
-\def\restore@tablenum{\if\use@tablenum0\else\setcounter{table}{\the\c@table@save}\addtocounter{table}{\m@ne}\gdef\use@tablenum{0}\fi}
+
+\let\savetablenum\tablenum
 
 \def\tabletypesize#1{\gdef\currtabletypesize{#1}
 \def\@table@type@size{#1}}%
@@ -1756,15 +1842,21 @@ the#1\endcsname}
 \def\LT@makecaption#1#2#3{%
   \LT@mcol\LT@cols c{\hbox to\z@{\hss\parbox[t]\LTcapwidth
 {%
-\def \@currentlabel{\thetable}
-     \sbox\@tempboxa{\small #2. #3}%
+\xdef \@currentlabel{\thetable}
+     \sbox\@tempboxa{\small #2. 
+%% disable trackchanges commands here, so they aren't entered 2 times:
+\let\added\relax
+\let\deleted\relax
+\let\replaced\relax
+#3}%
      \ifdim\wd\@tempboxa>\hsize
-      \small #2. #3%
+      \small#2. #3%
      \else
        \hbox to\hsize{\hfil\box\@tempboxa\hfil}%
      \fi
     \endgraf\vskip\baselineskip}%
-  \hss}}}
+  \hss}}
+}%% 
 
 \let\LT@makecaption@rtx=\LT@makecaption % to fight redefinition in Revtex-4.1
 
@@ -1772,12 +1864,12 @@ the#1\endcsname}
 %% from book.cls/ used??
 \long\def\@makecaption#1#2{%
   \vskip\abovecaptionskip
-\ifx\@captype\xfigure
-\gdef \@currentlabel{\thefigure}
-\else
-\gdef \@currentlabel{\thetable}\fi
 %% \small added to keep currtabletypesize from determining size of caption
   \sbox\@tempboxa{\small
+%% disable trackchanges commands here, so they aren't entered 2 times:
+\let\added\relax
+\let\deleted\relax
+\let\replaced\relax
 {\bf #1.} #2}%
   \ifdim \wd\@tempboxa >\hsize
 \small
@@ -1786,7 +1878,8 @@ the#1\endcsname}
     \global \@minipagefalse
     \hb@xt@\hsize{\hfill\box\@tempboxa\hfill}%
   \fi
-  \vskip\belowcaptionskip}
+  \vskip\belowcaptionskip
+}
 
 \newdimen\@abovenoteskip
 \newcommand\tablerefs[1]{\ifdim\@abovenoteskip=0pt\global\@abovenoteskip=10pt\fi
@@ -1799,8 +1892,8 @@ the#1\endcsname}
  {\hskip1em\rm References. --- #1}\par}%
 }%
 
-
-\global\def\tablenotemark#1{{\normalfont\textsuperscript{#1}}}
+%% march 2019, added \it to tablenotemark
+\global\def\tablenotemark#1{{\normalfont\textsuperscript{\normalsize\it #1}}}
 \global\def\tablenotetext#1#2{\footnotetext[#1]{\currtabletypesize\relax#2}}
 
 %% redefined by AH below, since it wasn't working with tabular table
@@ -1811,7 +1904,7 @@ the#1\endcsname}
 \def\xyztablehead#1{\@table@not@headedfalse%
   \kill
   \caption{\\%
-    \@tablecaption}%
+   \@tablecaption\gdef\@currentlabel{\thetable}(0)}
     \\\hline\hline%
   #1\vrule height 12pt depth 10pt width 0pt\relax 
 \hskip\tabcolsep\\[.7ex]
@@ -1874,6 +1967,7 @@ width0pt\relax#1$}\ignorespaces}
 
 \def\lt@expand@linewidth@one{\setlength\LTleft{0pt}\setlength\LTright{0pt}}
 \def\lt@expand@linewidth@two{@{\extracolsep{0pt plus 1filll}}}
+
 \def\find@table@width{%
 %%% set table width using aux file and command \tablewidth
     \setcounter{deluxe@table@num}{\c@LT@tables}
@@ -1981,8 +2075,17 @@ width0pt\relax#1$}\ignorespaces}
 \newcommand{\figsetplot}[1]{\noprint{#1}}
 \newcommand{\figsetgrpnote}[1]{\noprint{#1}}
 
-%% for url's in document, will allow them to break over lines.
 \usepackage{url}
+%% if we take away the xx before UrlBreaks we will get a url that breaks
+%% at any letter or number. It might be better to break only at / however...
+\expandafter\def\expandafter\xxUrlBreaks\expandafter{\UrlBreaks%  save the current one
+  \do\a\do\b\do\c\do\d\do\e\do\f\do\g\do\h\do\i\do\j%
+  \do\k\do\l\do\m\do\n\do\o\do\p\do\q\do\r\do\s\do\t%
+  \do\u\do\v\do\w\do\x\do\y\do\z\do\A\do\B\do\C\do\D%
+  \do\E\do\F\do\G\do\H\do\I\do\J\do\K\do\L\do\M\do\N%
+  \do\O\do\P\do\Q\do\R\do\S\do\T\do\U\do\V\do\W\do\X%
+  \do\Y\do\Z\do\1\do\2\do\3\do\4\do\5\do\6\do\7\do\8\do\9}
+
 
 %% for tables continuing over pages
 \usepackage{longtable}
@@ -1993,16 +2096,19 @@ width0pt\relax#1$}\ignorespaces}
 \definecolor{xlinkcolor}{cmyk}{1,1,0,0}
 
 
+\PassOptionsToPackage{hyphens}{url}
 %% In response to request from AAS
- \usepackage[bookmarks=false,         % show bookmarks bar?
+ \usepackage[bookmarks=true,         % show bookmarks bar?/ Changed March 22, 2019 for
+                                     % improved accessibility
      pdfnewwindow=true,      % links in new window
      colorlinks=true,    % false: boxed links; true: colored links
      linkcolor=xlinkcolor,     % color of internal links
      citecolor=xlinkcolor,     % color of links to bibliography
      filecolor=xlinkcolor,  % color of file links
      urlcolor=xlinkcolor,      % color of external links
-final=true
+     final=true,
  ]{hyperref}
+
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2139,10 +2245,10 @@ final=true
 \catcode`\$=\active
 
 \let\savetabular\tabular
-\def\tabular{\catcode`\&=\active\relax\catcode`\$=\active\relax\savetabular}
+\def\tabular{\catcode`\&=\active\relax\catcode`\$=\active\relax\hskip\movetableright
+\savetabular}
 \long\gdef\eatone{\setbox0=\hbox\bgroup\savedollar\let$\relax}
 \gdef\endeatone{\savedollar\egroup\hskip-2\tabcolsep}
-
 
 %% Hide, important because it allows us to split tables horizontally
 \newcolumntype{h}{>\eatone c<\endeatone}
@@ -3886,7 +3992,7 @@ Thank you!^^J}\fi%
 %\ifbreaktab
 \\\hline% below, hline is wanted
 %\else
-\noalign{\vskip-13pt}
+\noalign{\vskip-8pt}
 %\vrule height 28pt width0pt %the \vrule is in the line below colnumbers; 
                           % it causes all the vrules on that line to grow to 28pt.
                           % The -14pt will cause the lower line to overlap the upper line.
@@ -3894,6 +4000,7 @@ Thank you!^^J}\fi%
                           % have it also work for split tabular.
 %\fi
 }
+
 
 
 \let\savecolnumbers\colnumbers
@@ -4190,7 +4297,7 @@ Sorry, more than 30 columns cannot be numbered with^^J
 \string\colnumbers. Please number the columns manually.^^J
 Thank you!^^J}\fi%
 \\\hline% below, hline is wanted
-%\\\noalign{\vskip-30pt}
+\\\noalign{\vskip-30pt }%%%%% 
 %\vrule height 28pt width0pt %the \vrule is in the line below colnumbers; 
                           % it causes all the vrules on that line to grow to 28pt.
                           % The -14pt will cause the lower line to overlap the upper line.
@@ -4507,7 +4614,8 @@ Sorry, more than 30 columns cannot be numbered with^^J
 Thank you!^^J}\fi%
 \\\hline% below, hline is wanted
 \iffirsttime
-\\\noalign{\vskip-30pt}
+\\\noalign{\vskip-30pt}%% 
+%\noalign{\vskip-8pt}
 \vrule height 28pt width0pt %the \vrule is in the line below colnumbers; 
                           % it causes all the vrules on that line to grow to 28pt.
                           % The -14pt will cause the lower line to overlap the upper line.
@@ -4522,7 +4630,7 @@ Thank you!^^J}\fi%
 \global\let\extracolsep\relax
 \global\let\ddoit\saveddoit
 \global\let\zdoit\savezdoit
-\vskip-32pt
+\vskip-32pt 
 }{\vrule height28pt depth0pt width0pt}\relax}
 
 \def\splitdecimalcolnumbers{\\[-15pt]%
@@ -4537,7 +4645,7 @@ Thank you!^^J}\fi%
 }\vrule height 28pt width0pt %!!!
 \global\let\splitdecimalcolnumbers\secondsplitdecimalcolnumbers}
 
-\def\secondsplitdecimalcolnumbers{\omit\\%[-15pt]
+\def\secondsplitdecimalcolnumbers{\omit\\ 
 \plaincolnumbers
 \global\colnumbersonfalse
 \\\noalign{\vskip-26pt %!!! was -28pt
@@ -4577,10 +4685,12 @@ deluxetable*\endcsname{\deluxestartrue\bgroup\floattrue
 \def\floatrotatetable{\global\deluxestartrue\global\floattrue}
 \let\endfloatrotatetable\relax
 
-\def\deluxetable{
-\global\deluxetrue
+\def\deluxetable{\global\deluxetrue
 \catcode`\&=\active
 \catcode`\$=\active
+%% Mar 30, 2019, to make label outside of \caption work correctly
+{\advance\c@table by 1
+\xdef\@currentlabel{\thetable}}
 \let\tablecaption\deluxetablecaption
 \deluxetablecaption{}
 %% july 2016
@@ -4589,13 +4699,16 @@ deluxetable*\endcsname{\deluxestartrue\bgroup\floattrue
 % \else\let\go\longdeluxetable\fi\go%}
 %% aug 2016
 \ifstartlongtable
+%% this works for both deluxetable and deluxetable*:
 %% nov 2017:
 \def\arraystretch{1.1}
-   \ifdeluxestar
+%% March 2019 
+\if@two@col\global\returntotwocoltrue\vskip1pt
+\ifdeluxestar\onecolumngrid\fi\fi
+%%
+\ifdeluxestar
 \vskip12pt
-   \if@two@col\onecolumngrid
-   \vskip12pt
-   \fi\fi
+\fi
 \let\go\longdeluxetable
 \else
 \let\go\ydeluxetable
@@ -4605,8 +4718,10 @@ deluxetable*\endcsname{\deluxestartrue\bgroup\floattrue
 \def\ydeluxetable#1{%
 \@ifnextchar[{\xdeluxetable{#1}}{\zdeluxetable{#1}}}
 
+%%
 % x and z are the same, except that xdeluxetable allows optional square bracket arg, like [h].
 \def\xdeluxetable#1[#2]{\global\breaktabtrue
+%% not here
 \let\colnumbers\deluxecolnumbers
 \global\deluxedecimalsfalse
 \let\decimals\deluxedecimals
@@ -4639,10 +4754,12 @@ deluxetable*\endcsname{\deluxestartrue\bgroup\floattrue
 \pt@head
 ##1\end{tabular}}
 \expandafter\ifx\csname @tablecaption\endcsname\empty\else
-
+%% 
 \noindent\hbox
 to\hsize{\hss\vtop{\hsize=\wd0
 \caption{\@tablecaption}}\hss}\vskip3pt\fi
+
+%% not here
 \global\setbox3\hbox{%
 \begin{tabular}{#1}%
 \hline\hline\noalign{\vskip-9pt}%
@@ -4686,7 +4803,6 @@ to\hsize{\hss\vtop{\hsize=\wd0
 \pt@head
 ##1\end{tabular}}% not here
 \expandafter\ifx\csname @tablecaption\endcsname\empty\else
-
 \noindent\hbox
 to\hsize{\hss\vtop{\hsize=\wd0
 \caption{\@tablecaption}}\hss}\vskip3pt\fi
@@ -4702,8 +4818,25 @@ to\hsize{\hss\vtop{\hsize=\wd0
 \leftskip6pt\parindent-6pt
 }}
 
+
 %% go to \end{deluxetable}, after longdeluxetable
 
+
+
+%%@@@@
+
+%% Variation on definition found in revtex4-1.cls
+\def\LT@start@new{%
+ \let\LT@start\endgraf
+ \endgraf
+ \markthr@@{}%
+ \LT@pre
+ \@ifvoid\LT@firsthead{\LT@top}{\hbox{\ifdim\movetableright>0pt\relax\hskip\movetableright\fi\box\LT@firsthead}
+\nobreak}%
+ \mark@envir{longtable}%
+}%
+
+%%% 
 \newbox\longtablebox
 \def\longdeluxetable#1{
 \global\rotateonfalse
@@ -4735,16 +4868,43 @@ to\hsize{\hss\vtop{\hsize=\wd0
 \bgroup\centering
 \def\table@hook{\currtabletypesize}
       \LTcapwidth=\wd\longtablebox
-\begin{longtable}{#1}%%
+%% march 2019, added [c] and these terms: 
+\ifcenterwidetable\global\centerwidetablefalse
+  \def\LT@LR@c{\LTleft=0pt minus1fill 
+  \let\LTright\LTleft}%
+\else
+%% default, will center table that is narrower than text width
+  \def\LT@LR@c{\LTleft=0pt plus1fill 
+  \LTright\LTleft}%
+\fi
+%%
+%
+\begin{longtable}[c]{#1}%%
+\ifdim\movetableright>0pt
+ \noalign{\ifdim\movetableright>0pt
+  \global\LTleft=\movetableright
+ \fi}
+%
+ \noalign{\hbox to \wd\longtablebox{
+ \vtop{\hsize=.8\wd\longtablebox 
+  \advance\baselineskip4pt
+ \raggedright
+  {\bf \fnum@table}.\vrule depth 6pt width0pt\
+  \@tablecaption}\hss}\vskip-3pt }\\
+  \hline
+  \hline\noalign{\vskip-9pt}
+ \pt@head%
+\else
 \caption{\hsize=\wd\longtablebox 
 \advance\baselineskip2pt
-\@tablecaption}\\
+\@tablecaption}\\ %
 \hline\hline\noalign{\vskip-9pt}% prob ok
 \pt@head%
+\fi
 \endfirsthead
 
 \noalign{\centerline{\small 
-{\bf Table \thetable}\ \it(continued)}\vskip6pt}
+\hskip\movetableright{\bf \fnum@table}\ \it(continued)}\vskip6pt}
 \hline\hline
 \noalign{\vskip-12pt}
 \pt@head%
@@ -4752,7 +4912,7 @@ to\hsize{\hss\vtop{\hsize=\wd0
 
 \hline
 \multicolumn{\totalcolumns}{c}{\vrule height 24pt width0pt\small\it
-Table \thetable\
+\fnum@table\
 continued  \if@two@col\else on next page\fi}\\ 
 \endfoot
 
@@ -4772,11 +4932,13 @@ continued  \if@two@col\else on next page\fi}\\
 \parindent=-6pt
 \currtabletypesize
 \global\startlongtablefalse
+\global\movetableright=0pt
 }% end data, endlongtable
 }
 
-
-\def\endlongdeluxetable{\vrule depth 6pt width 0pt
+\def\endlongdeluxetable{
+%%
+\vrule depth 6pt width 0pt
 \vskip1sp
 \egroup
 \ifdim\dp4>6pt
@@ -4784,23 +4946,26 @@ continued  \if@two@col\else on next page\fi}\\
 \vbox{\hbox to \columnwidth{\hfill
 \vtop{\hsize\wd\longtablebox
 \leftskip=6pt\parindent-6pt
-\copy4}\hfill}
-}\fi
-\ifdeluxestar
- \if@two@col
-\vglue\ht4
- \twocolumngrid
- \hsize=\columnwidth
-\fi\fi%
+\copy4
+}\hfill}%%
+}
+\fi
+\vglue\ht4 
 \global\colnumbersonfalse
 \global\deluxedecimalsfalse
 \global\rotateonfalse
-%\global\floatfalse
-\if@two@col\vskip12pt\twocolumngrid\fi
+%%
 \relax\null%% \null is an empty hbox.
 %% This keeps final page(s) of startlongtable/deluxetable
 %% from begin thrown away when at end of article.
-}
+% \global\advance\c@table-1\relax
+%%
+%
+%% march 2019
+\ifreturntotwocol\global\returntotwocolfalse
+\twocolumngrid\fi
+}%% 
+
 
 %% bbb
 %% \end{deluxetable}:
@@ -4823,7 +4988,8 @@ continued  \if@two@col\else on next page\fi}\\
 \ifdeluxestar\end{table*}\global\deluxestarfalse
 \if@two@col
 \twocolumngrid\hsize=\columnwidth\fi%% check this!!
-\else\end{table}\fi
+\else
+\end{table}\fi
 \gdef\colnumbers{\saveplaincolnumbers}
 \global\breaktabfalse
 \global\deluxefalse
@@ -4831,18 +4997,25 @@ continued  \if@two@col\else on next page\fi}\\
 \global\deluxedecimalsfalse
 \global\rotateonfalse
 \startlongtablefalse
+\global\movetableright=0pt
 %\global\floatfalse
+%\global\advance\c@table by -1\relax
 }%% check this!!
 
-
+%%@@@ ???
 
 \newbox\splitbox
 \newif\ifdeluxe
-\def\splitdeluxetable{\global\deluxetrue\catcode`\&=\active
+\def\splitdeluxetable{
+%% Mar 30, 2019, to make label outside of \caption work correctly
+{\advance\c@table by 1
+\xdef\@currentlabel{\thetable}}
+\global\deluxetrue\catcode`\&=\active
 \catcode`\$=\active
 \xsplitdeluxetable}
 
-\def\xsplitdeluxetable#1{\global\breaktabtrue
+\def\xsplitdeluxetable#1{
+\global\breaktabtrue
 \let\colnumbers\deluxecolnumbers
 \let\decimals\deluxedecimals
 \global\deluxedecimalsfalse
@@ -4909,6 +5082,7 @@ continued  \if@two@col\else on next page\fi}\\
 \global\colnumbersonfalse
 \global\deluxedecimalsfalse
 }
+
 
 \newif\ifsplitstar
 \expandafter\def\csname splitdeluxetable*\endcsname{\global\splitstartrue\splitdeluxetable}
@@ -4985,7 +5159,7 @@ continued  \if@two@col\else on next page\fi}\\
 \setbox\secondtablebox=\hbox{%
 \begin{tabular}{fZE}%
 \ifx\csname pt@head\endcsname\relax\else%
-\pt@head\fi\\[-14pt]%
+\pt@head\fi\\ [-14pt]% 
 #1\crcr%
 \end{tabular}}
 \fi
@@ -5071,14 +5245,13 @@ continued  \if@two@col\else on next page\fi}\\
 %% xstartdata, modified from \startdata in emulateapj, for splitdeluxetable
 \gdef\xstartdata#1\enddata{\def\tablecontents{%
 \ifcolnumberson%
-\\ \savecolnumbers\\[2pt]\fi%
+\\\savecolnumbers\\[2pt]\fi% this is for top level split
 \ifdeluxedecimals\savedecimals\fi%
 #1}%
 \currtabletypesize%
 \setbox2=\vtop{\dbreaktabular{\tablecontents}}%
 %
 \expandafter\ifx\csname @tablecaption\endcsname\empty\else
-
 \noindent\hbox
 to\hsize{\hss\vtop{\hsize=\maxtablewidth\caption{\@tablecaption}}\hss}\vskip3pt\fi
 \dbreaktabular{\tablecontents\noalign{\global\let\zdoit\relax
@@ -5166,7 +5339,7 @@ width 0pt\currtabletypesize{\bf References}---{#1}\vskip1sp}}
 \catcode`\$=\active%
 \xxtablehead}
 
-%% ++=
+%%
 \def\xxtablehead#1{%
 \let&\CheckNumberAndSwitch%
 \gdef\pt@head{%
@@ -5204,7 +5377,7 @@ width 0pt\currtabletypesize{\bf References}---{#1}\vskip1sp}}
 \fi%end iftwelvepoint
 #1\ifcolnumberson%
 \ifnotfirst\\[-22pt]\fi
-\else\\\hline\\[-8pt]\fi% space below hline for 2nd and 3rd part of split table
+\else\\\hline\\[-8pt]\fi% space below hline for 2nd and 3rd part of split table 
 }%
 %
 }
@@ -5213,7 +5386,6 @@ width 0pt\currtabletypesize{\bf References}---{#1}\vskip1sp}}
 \catcode`\$=\active%
 \zztablehead}
 
-%% +++
 \def\zztablehead#1{\let&\CheckNumberAndSwitch%
 \gdef\pt@head{%
 %% this is needed:
@@ -5247,7 +5419,7 @@ width 0pt\currtabletypesize{\bf References}---{#1}\vskip1sp}}
               \fi% end ifonecol
    \fi%endiftwocolstyle
 \fi%end iftwelvepoint
-#1%
+#1\unskip%
 \ifcolnumberson\\[6pt]
 \savecolnumbers\vrule height 11pt depth 4pt width 0pt\relax%
 \\\ifmanu\noalign{\vskip-15pt}\fi%
@@ -5358,11 +5530,14 @@ by 1\relax}\ignorespaces}%
 \expandafter \let \csname endtable*\endcsname = \endtable
 %%
 
+
+%%% \movetabledown works
 \newbox\rotatetablebox
 \def\rotatetable{%
 \clearpage
 \global\startlongtabletrue\setbox\rotatetablebox=\vbox\bgroup
 }
+
 \def\endrotatetable{\egroup
 \vglue\movetabledown
 \hbox to
@@ -5371,12 +5546,11 @@ by 1\relax}\ignorespaces}%
 \global\startlongtablefalse
 }
 
-
+%%% \movetabledown works
 \expandafter\def\csname rotatetable*\endcsname{%
 \clearpage
 \global\startlongtabletrue\setbox\rotatetablebox=\vbox to
 \textwidth\bgroup\vfill}
-
 
 \expandafter\def\csname endrotatetable*\endcsname{\vfill\egroup
 \vbox to \textheight{\vfill
@@ -5390,7 +5564,8 @@ by 1\relax}\ignorespaces}%
 \global\startlongtablefalse
 }
 
-
+%
+%%% \movetabledown works
 \newif\iflongrotateon
 \def\longrotatetable{%
 \global\longrotateontrue
@@ -5418,6 +5593,7 @@ by 1\relax}\ignorespaces}%
   \@colht=\vsize
   \def\@makecol{\LS@makecol\LS@rot}%
   \def\@makefcolumn##1{\LS@makefcolumn{##1}\LS@rot}}
+
 \def\endlongrotatetable{%
 \onecolumngrid %% ??
 \clearpage
@@ -5433,7 +5609,6 @@ by 1\relax}\ignorespaces}%
   \global\@colht=\textheight
   \global\vsize=\textheight
   \global\@colroom=\textheight}
-
 
 \newif\ifGin@pdftex
 \Gin@pdftexfalse
@@ -5523,9 +5698,9 @@ by 1\relax}\ignorespaces}%
 %% standardized, so didn't make an user interface
 %% to change the colors easily.
 
-\expandafter\def\csname editcolor1\endcsname{magenta}
-\expandafter\def\csname editcolor2\endcsname{blue}
-\expandafter\def\csname editcolor3\endcsname{violet}
+\expandafter\def\csname editcolor1\endcsname{black}% was magenta
+\expandafter\def\csname editcolor2\endcsname{black}% was blue
+\expandafter\def\csname editcolor3\endcsname{black}% was violet
 
 \newcount\colorcount
 \def\edit#1#2{{\colorcount=#1\relax%
@@ -5636,8 +5811,8 @@ to 20pt{\hfill}}\vskip12pt}%
 \fboxrule=4pt
 \fboxsep=12pt
 \fcolorbox{ltblue}{white}{\hbox to
-.93\textwidth{\hss$\vcenter{\advance\hsize -24pt #1}$\hss}}}\gdef\highlightfigure{\typeout{^^J^^JERROR!^^J^^J
-Only One Highlighted Figure per Article!^^J^^J}\stop}}
+.93\textwidth{\hss$\vcenter{\advance\hsize -24pt #1}$\hss}}
+}}
 
 
 %%%%%%%%%%%%%
@@ -5675,8 +5850,8 @@ Only One Highlighted Figure per Article!^^J^^J}\stop}}
 %% Change Feb 2016, to allow optional argument for time/date, and/or editor initials, etc.
 
 
-\providecolor{trackchange}{rgb}{1,0,0}
-\providecolor{explain}{rgb}{.5,0,.5}
+\providecolor{trackchange}{cmyk}{0,0,0,1}
+\providecolor{explain}{cmyk}{0,0,0,1}
 
 \newif\ifsilent
 
@@ -5692,14 +5867,14 @@ Only One Highlighted Figure per Article!^^J^^J}\stop}}
 \ifabstract\else%
 \xdef\doit{\noexpand\linelabel{\the\refchangenumber}}\doit\fi\else%
 \xdef\doit{\noexpand\label{\the\refchangenumber}{}{}{}}\doit\fi}%
-{\color{trackchange}(Added: [#1] #2)}%%
+{\color{trackchange}\bf(Added: [#1] #2)}%%
 \ifabstract\label{\the\refchangenumber}%
 \expandafter\gdef\csname
 changenum\the\refchangenumber\endcsname{Added: [#1]
-\textcolor{trackchange}{#2}\global\silenttrue}%
+\textcolor{trackchange}\bf\relax{#2}\global\silenttrue}%
 \else\expandafter\gdef\csname
-changenum\the\refchangenumber\endcsname{Added: [#1]
-\textcolor{trackchange}{\let\bibitem\specialbibitem #2}\global\silentfalse}\fi%
+changenum\the\refchangenumber\endcsname{\bf\relax Added: [#1]
+\textcolor{trackchange}\bf\relax{\let\bibitem\specialbibitem #2}\global\silentfalse}\fi%
 \else#2\fi}
 
 
@@ -5713,16 +5888,16 @@ changenum\the\refchangenumber\endcsname{Added: [#1]
 \xdef\doit{\noexpand\linelabel{\the\refchangenumber}}\doit\fi\else%
 \xdef\doit{\noexpand\label{\the\refchangenumber}{}{}{}}\doit%
 \fi}%
-{\color{trackchange}(Added: #1)}%%
+{\color{trackchange}\bf(Added: #1)}%%
 \ifabstract%
 \label{\the\refchangenumber}%
 \expandafter\gdef\csname
 changenum\the\refchangenumber\endcsname{Added:
-\textcolor{trackchange}{#1},
+\textcolor{trackchange}\bf\relax{#1},
 \global\silenttrue}\else
 \expandafter\gdef\csname
 changenum\the\refchangenumber\endcsname{Added:
-\textcolor{trackchange}{\let\bibitem\specialbibitem #1},%
+\textcolor{trackchange}{\bf\relax\let\bibitem\specialbibitem #1},%
 \global\silentfalse}\fi%
 \else#1\fi}
 
@@ -5740,7 +5915,7 @@ changenum\the\refchangenumber\endcsname{Added:
 \else%
 \xdef\doit{\noexpand\label{\the\refchangenumber}}\doit\fi%
 }%
-{\color{trackchange}%
+{\color{trackchange}\bf%
 \ifbib\let\sout\relax\fi%
 \let\citep\specialcitep%
 \let\citet\specialcitet%
@@ -5749,7 +5924,7 @@ changenum\the\refchangenumber\endcsname{Added:
 \ifabstract\label{\the\refchangenumber}%
 \expandafter\gdef\csname
 changenum\the\refchangenumber\endcsname{Deleted: [#1]
-{\color{trackchange}%
+{\color{trackchange}\bf%
 \let\citet\specialcitet%
 \let\citep\specialcitep%
 \let\cite\specialcite\sout{#2}}\global\silenttrue}%
@@ -5776,7 +5951,7 @@ changenum\the\refchangenumber\endcsname{Deleted: [#1]
 \xdef\doit{\noexpand\label{\the\refchangenumber}{}{}{}}\doit%
 \fi}%
 %%
-{\color{trackchange}%
+{\color{trackchange}\bf%
 \ifbib\let\sout\relax\fi%
 \let\citep\specialcitep%
 \let\citet\specialcitet%
@@ -5784,13 +5959,13 @@ changenum\the\refchangenumber\endcsname{Deleted: [#1]
 )}%
 \ifabstract\label{\the\refchangenumber}%
 \expandafter\gdef\csname changenum\the\refchangenumber\endcsname{Deleted:
-{\color{trackchange}\let\ref\specialref%
+{\color{trackchange}\bf\let\ref\specialref%
 \let\citep\specialcitep%
 \let\citet\specialcitet%
 \let\cite\specialcite\sout{#1}}\global\silenttrue}%
 \else
 \expandafter\gdef\csname changenum\the\refchangenumber\endcsname{Deleted:
-{\color{trackchange}%
+{\color{trackchange}\bf%
 \let\citep\specialcitep%
 \let\citet\specialcitet%
 \let\bibitem\specialbibitem%
@@ -5811,27 +5986,27 @@ changenum\the\refchangenumber\endcsname{Deleted: [#1]
 {\ifbib\let\sout\relax\fi
 \let\citep\specialcitep%
 \let\citet\specialcitet%
-\let\cite\specialcite\color{trackchange}(Replaced: [#1] \sout{#2}}%
+\let\cite\specialcite\color{trackchange}\bf(Replaced: [#1] \sout{#2}}%
 {\color{black}replaced with:} {\let\ref\specialref%
 \let\citep\specialcitep%
 \let\citet\specialcitet%
-\let\cite\specialcite\color{trackchange} #3)}%
+\let\cite\specialcite\color{trackchange}\bf\relax #3)}%
 \ifabstract\label{\the\refchangenumber}%
 \expandafter\gdef\csname
 changenum\the\refchangenumber\endcsname{Replaced: [#1]
 {\let\citep\specialcitep%
 \let\citet\specialcitet%
-\let\cite\specialcite\color{trackchange}\sout{#2}} {\color{black} replaced with:}
-{\color{trackchange}#3}, \global\silenttrue}%
+\let\cite\specialcite\color{trackchange}\bf\relax\sout{#2}} {\color{black} replaced with:}
+{\color{trackchange}\bf\relax#3}, \global\silenttrue}%
 \else
 \expandafter\gdef\csname
 changenum\the\refchangenumber\endcsname{Replaced: [#1]
 {\ifbib\let\sout\relax\fi\let\bibitem\specialbibitem
 \let\citep\specialcitep%
 \let\citet\specialcitet%
-\let\cite\specialcite\color{trackchange}\sout{#2}
+\let\cite\specialcite\color{trackchange}\bf\relax\sout{#2}
 } {\color{black} replaced with:}
-{\let\bibitem\specialbibitem\color{trackchange}#3}, \global\silentfalse}\fi%
+{\let\bibitem\specialbibitem\color{trackchange}\bf\relax#3}, \global\silentfalse}\fi%
 \else#3\fi}
 
 \long\def\yreplaced#1#2{%
@@ -5844,35 +6019,35 @@ changenum\the\refchangenumber\endcsname{Replaced: [#1]
 {\ifbib\let\sout\relax\fi\let\ref\specialref%
 \let\citep\specialcitep%
 \let\citet\specialcitet%
-\let\cite\specialcite\color{trackchange}(Replaced: %\sout
+\let\cite\specialcite\color{trackchange}\bf\relax(Replaced: %\sout
 {#1}
 }%
 {\color{black}replaced with:}
-{\color{trackchange} #2)}%
+{\color{trackchange}\bf\relax #2)}%
 \ifabstract\label{\the\refchangenumber}%
 \expandafter\gdef\csname changenum\the\refchangenumber\endcsname{Replaced:
 {\let\cite\specialcite%
 \let\citep\specialcitep%
 \let\citet\specialcitet%
-\color{trackchange}\sout{#1}} {\color{black} replaced with:}
-{\color{trackchange}#2},\global\silenttrue}%
+\color{trackchange}\bf\relax\sout{#1}} {\color{black} replaced with:}
+{\color{trackchange}\bf\relax#2},\global\silenttrue}%
 \else
 \expandafter\gdef\csname
 changenum\the\refchangenumber\endcsname{Replaced:
 {\ifbib\let\sout\relax\fi\let\bibitem\specialbibitem
 \let\citep\specialcitep%
 \let\citet\specialcitet%
-\let\cite\specialcite\color{trackchange}\sout{#1}
+\let\cite\specialcite\color{trackchange}\bf\relax\sout{#1}
 } {\color{black} replaced with:}
-{\let\bibitem\specialbibitem\color{trackchange}#2}, \global\silentfalse}\fi%
+{\let\bibitem\specialbibitem\color{trackchange}\bf\relax#2}, \global\silentfalse}\fi%
 \else#2\fi}
 
 \def\explain{\@ifnextchar[{\xexplain}{\yexplain}}
 
-\def\xexplain[#1]#2{\iftrack\ {\it\color{explain} [Explanation of change:
+\def\xexplain[#1]#2{\iftrack\ {\bfseries\itshape\color{explain} [Explanation of change:
 #2 (#1)]\ }\fi}
 
-\def\yexplain#1{\iftrack\ {\it\color{explain} [Explanation of change:
+\def\yexplain#1{\iftrack\ {\bfseries\itshape\color{explain} [Explanation of change:
 #1]\ }\fi}
 
 \newcount\listchangenum
@@ -6002,7 +6177,7 @@ on page
 %% package. Making \caption[] be the default, to prevent sending caption 
 %% text to listoftables or listoffigures, which we are not going to use
 %% anyway. This change enables track changes commands to work in captions.
-
+\def\xtable{table}
 \def\caption{\numlinesfalse
 \ifx\@captype\@undefined 
 \@latex@error {\noexpand \caption outside float}\@ehd 
@@ -6013,7 +6188,6 @@ on page
 \float@caption\let\Hy@tempa\Hy@float@caption\fi} 
 \expandafter\@firstofone\fi 
 {\@dblarg {\Hy@tempa \@captype}}[]}
-
 
 \def\@caption#1[#2]#3{{\small\rm\expandafter \ifx \csname if@capstart\expandafter \endcsname 
 \csname iftrue\endcsname \global \let \@currentHref \hc@currentHref \else \hyper@makecurrent {\@captype }\fi 
@@ -6027,10 +6201,11 @@ on page
 \else \@makecaption {\bf\csname fnum@#1\endcsname }{\ignorespaces \ifHy@nesting 
 \expandafter \hyper@@anchor \expandafter {\@currentHref }{#3}\else 
 \Hy@raisedlink {\expandafter \hyper@@anchor \expandafter
-{\@currentHref }{\relax }}{#3}\fi }\fi \par \endgroup}}
+{\@currentHref }{\relax }}{#3}\fi }\fi \par
+\endgroup}}
 
-
-\newcommand\tablebreak{\\[-11pt]\noalign{\break}\\ }
+%% changed, March 23, 2019, took out \\ at end of definition:
+\newcommand\tablebreak{\\[-11pt]\noalign{\break}}
 
 %% As suggested by Greg Schwarz, August Meunch, Feb 11
 
@@ -6049,19 +6224,28 @@ on page
 %% are supplied with \author[0000-2345-3333-0023]{author name}
  \def\lookforbracket{\ifx\next[\let\go\xauthor
  \else\let\go\yauthor\fi\go}
- 
-\def\author{\futurelet\next\lookforbracket}
+
+\newcount\entriesinthiscollab 
+\newcount\allentries
+\newif\ifseesmessage
+\def\author{\global\advance\entriesinthiscollab by 1
+\global\advance\allentries by 1\relax\futurelet\next\lookforbracket}
 
 \def\new@author@def#1#2{%
  \move@AU\move@AF\move@AUAF
  \let\@AF@join\@author@join
- \def\@author{{\href{http://orcid.org/#1}{#2}}{}}%
+ \def\@author{{\href{http://orcid.org/#1}{#2%
+\openin1 Orcid-ID.png \ifeof1
+%% message for authors??
+%\typeout{^^J^^J  ! Missing File: Orcid-ID.png; needed for Orcid Author icon !
+%^^J}
+\else%
+\hskip2pt\includegraphics[width=9pt]{Orcid-ID.png}\fi}}{}}%
 }%
 
 \def\orciderrormessage{
 \typeout{^^J^^J [\firstarg]\space Invalid ORCID Identifier!^^J^^J The ID
-should consist of
-four sets of four digits,^^J separated with -, ie,
+should consist of four sets of four digits,^^J separated with -, ie,
 0000-0012-3245-1234 or ^^J
 0000-0012-3245-123X
 ^^J^^J
@@ -6239,14 +6423,21 @@ needed. It will not do anything.^^J Please use
 \ifnum\nine>\largestAffilNum
 \global\largestAffilNum=\nine\fi\fi
 }
-\newcount\countauthors
 
-
-\gdef\newcomma@space{\hskip-3pt\textsuperscript{,}}%
-
+%\gdef\newcomma@space{\hskip-3pt\textsuperscript{,}}%
 \def\doEtAl{\rm et al.\gdef\doEtAl{\relax}}
+%% =====================
+\newif\iffirsttime
+\firsttimetrue
+\newcount\totalentries
+\newcount\docollabnum
+\newcount\tempauthornumber
+\newcount\countauthors
+\newif\ifdothis
+\def\doAnd{}
+\newcount\testnum
 
-\def\doauthor#1#2#3{%
+\def\olddoauthor#1#2#3{%
 \iflongauthor\vskip6pt\fi
 \global\advance\countauthors by 1
 \ifnum\countauthors>\AuthorCollaborationLimit
@@ -6274,6 +6465,255 @@ needed. It will not do anything.^^J Please use
 \@listand\fi 
 }%
 
+\def\doauthor#1#2#3{%
+\iflongauthor\vskip6pt\fi
+%%%
+\ifanonymous
+    \iffirsttime
+     \global\firsttimefalse
+     Anonymous author(s)
+    \fi
+\else %% ends at end of this def
+%%%
+\ifnum\docollabnum< 1
+\global\AuthorCollaborationLimit\expandafter\csname
+currCollabLimit0\endcsname 
+%% this won't change until after collaboration name at end
+\fi %% end ifnum\docollabnum
+%%
+%%%%%%%%%%%%%%%%
+\global\advance\totalentries by 1
+\global\advance\countauthors by 1
+%%%
+\ifallauthors\global\AuthorCollaborationLimit=9999 \fi
+%%%
+% for testing
+% [author number=\the\countauthors/ auth collab limit
+% =\the\AuthorCollaborationLimit]
+%
+\gdef\xone{#1}
+\ifnum\countauthors < \AuthorCollaborationLimit
+\gdef\docomma{,}\else\gdef\docomma{}\fi
+%%%
+\ifnum\countauthors = \AuthorCollaborationLimit
+\ifnum\AuthorCollaborationLimit=1\else
+\gdef\doAnd{And }\fi
+\ifnum\tempauthornumber= 1
+\gdef\doAnd{  } \fi\fi
+%%
+{\tempauthorminusone=\AuthorCollaborationLimit
+\advance\tempauthorminusone by -1
+\ifnum\countauthors=\tempauthorminusone
+\gdef\doAnd{And }
+\gdef\docomma{}\fi}%
+%%%
+\global\dothisfalse
+%% if num countauthors is less than or equal to \AuthorCollaborationLimit, print name
+\ifnum\countauthors< \AuthorCollaborationLimit
+%%% 
+\ifx\xone\empty\else
+\global\dothistrue
+%\expandafter\gdef\csname
+%dothisaffil-\the\countauthors\the\docollab\endcsname{dothisone}
+  \ignorespaces\leavevmode\hbox{#1\unskip\docomma}% nice, keeps name from breaking across lines
+\fi
+\fi
+%%
+\ifnum\countauthors= \AuthorCollaborationLimit
+%%% 
+\ifx\xone\empty\else
+\global\dothistrue
+  \ignorespaces\leavevmode\hbox{\doAnd #1\unskip\docomma}% nice, keeps name from breaking across lines
+\fi
+\fi
+%% ++++
+%%
+\ifsuppressAffiliations\else
+\ifx\xone\empty\else
+ \begingroup
+\ifnum\countauthors>\AuthorCollaborationLimit\else
+  #3% all affil numbers
+\ifx\@affilID@temp\empty %% number following author
+\else%
+\setbox0=\hbox{\expandafter\lookfornumbers\@affilID@temp{}{}{}{}{}{}{}{}{}}%
+\fi\fi
+%% #2= \altaffiliation{} or \email{} or 
+%% possibly anything other than author, affiliation, or collaboration 
+  \@if@empty{#2}{\endgroup{}{}}
+{\ifnum\countauthors>\AuthorCollaborationLimit\endgroup{}{}%% <<< bug fix, added \endgroup{}{}
+\else
+\endgroup{\comma@space}{}\frontmatter@footnote{#2}\fi}%
+\fi%% end test of empty
+\fi%% end test of suppressAffiliations
+%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Collaboration name is always used if available:
+\expandafter\ifx\csname currCollabName\the\totalentries\endcsname\relax\else 
+%%%
+%%%
+%%%
+%% changed locally:
+{\advance\docollabnum 1 
+\advance\countauthors-1
+%%%
+%%% We need to test to see if more than one author in collaboration
+%%% and if the number of authors is greater than the \AuthorCollaborationLimit.
+%%% If both of these are true, than use `et al.' , otherwise do not:
+\expandafter\ifx\csname
+CollabTotalAuthors\the\docollabnum\endcsname\relax
+\else
+\expandafter\ifnum\csname
+CollabTotalAuthors\the\docollabnum\endcsname
+< 2 %%%%% Don't use et al if there is only one author
+\else
+\expandafter\ifnum\csname CollabTotalAuthors\the\docollabnum\endcsname
+>\AuthorCollaborationLimit
+\ifnum\AuthorCollaborationLimit=0\else
+\vskip3pt
+{\rm et al.} \vskip-3pt
+\fi\fi\fi\fi
+}%% end local change to docollabnum
+%%%%
+\expandafter\ifx\csname
+currCollabName\the\totalentries\endcsname\empty
+\vskip-3pt
+\else
+\vskip6pt
+\expandafter\csname currCollabName\the\totalentries\endcsname\vskip8pt
+\affiliation{testing}
+\fi
+%%%%%%%%
+\global\countauthors=0
+%%%
+%%%
+\global\advance\docollabnum  by 1
+%% Set up counters for next time through this loop:
+{\advance\docollabnum by1
+  \expandafter\ifx\csname
+  specificCollabLimit\the\docollabnum\endcsname\relax
+ \else
+   \global\AuthorCollaborationLimit=\csname
+   specificCollabLimit\the\docollabnum\endcsname 
+  \fi
+\expandafter\ifx\csname
+CollabTotalAuthors\the\docollabnum\endcsname\relax
+\else
+\global\tempauthornumber=\csname
+CollabTotalAuthors\the\docollabnum\endcsname
+\fi
+}
+\fi %% ends test to see if it is time to use collaboration name
+\fi %% ends ifanonymous
+}%
+
+
+%%%% ++++====
+\newcount\tempauthorminusone
+%% +++
+\def\doAllauthors#1#2#3{%
+\global\suppressAffiliationsfalse
+\iflongauthor\vskip6pt\fi
+%%%
+\ifanonymous
+    \iffirsttime
+     \global\firsttimefalse
+     Anonymous author(s)
+    \fi
+\else %% ends at end of this def
+%%%
+\ifnum\docollabnum< 1
+%% these won't change until after collaboration name at end
+\global\AuthorCollaborationLimit\expandafter\csname currCollabLimit0\endcsname 
+\global\tempauthornumber=\csname CollabTotalAuthors1\endcsname
+\fi%% end ifnum\docollabnum
+%%
+%%%%%%%%%%%%%%%%
+\global\advance\totalentries by 1
+\global\advance\countauthors by 1
+%%%
+\ifallauthors\global\AuthorCollaborationLimit=9999 \fi
+%%%
+% for testing
+%[author number=\the\countauthors/ temp author
+%=\the\tempauthornumber]
+\def\one{#1}
+{\tempauthorminusone=\tempauthornumber
+\advance\tempauthorminusone by -1
+\ifnum\countauthors < \tempauthornumber
+\gdef\xdocomma{,}%
+\else\gdef\xdocomma{}\fi%
+%%%
+\ifnum\countauthors = \tempauthornumber
+\gdef\xdoAnd{And}\gdef\xdocomma{}%
+\else\gdef\xdoAnd{}\fi%
+\ifnum\tempauthornumber= 1
+\gdef\xdoAnd{}\gdef\xdocomma{}\fi%
+\ifnum\countauthors=\tempauthorminusone
+\gdef\xdocomma{}\fi%
+}
+%%%
+%% if num countauthors is less than or equal to \AuthorCollaborationLimit, print name
+\ifnum\countauthors< \AuthorCollaborationLimit
+%%% 
+\ifx\one\empty\else
+  \ignorespaces\leavevmode\hbox{\unskip\xdoAnd\ #1\unskip\xdocomma}% nice, keeps name from breaking across lines
+\fi\fi%
+%%
+\ifnum\countauthors= \AuthorCollaborationLimit
+%%% 
+\ifx\one\empty\else
+\ignorespaces\leavevmode\hbox{\unskip\xdoAnd\ #1\unskip\xdocomma}% nice, keeps name from breaking across lines
+\fi%
+\fi%
+%%
+\ifx\one\empty\else
+ \begingroup
+\ifnum\countauthors>\AuthorCollaborationLimit\else
+  #3% all affil numbers
+\ifx\@affilID@temp\empty
+\else%
+\setbox0=\hbox{\expandafter\lookfornumbers\@affilID@temp{}{}{}{}{}{}{}{}{}}%
+\fi\fi
+%% #2= \altaffiliation{} or \email{} or 
+%% possibly anything other than author, affiliation, or collaboration 
+  \@if@empty{#2}{\endgroup{}{}}
+{\ifnum\countauthors>\AuthorCollaborationLimit\endgroup{}{}%% <<< bug fix, added \endgroup{}{}
+\else
+\endgroup{\comma@space}{}\frontmatter@footnote{#2}\fi}%
+\fi%% end test of empty
+%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Collaboration name is always used if available:
+\expandafter\ifx\csname currCollabName\the\totalentries\endcsname\relax\else 
+%%%
+%% No et al in allauthors, because all authors are listed!
+%%
+\expandafter\ifx\csname
+currCollabName\the\totalentries\endcsname\empty
+\else
+\vskip6pt
+\expandafter\csname currCollabName\the\totalentries\endcsname\vskip6pt
+\fi
+\global\countauthors=0
+%%%
+%%%
+\global\advance\docollabnum  by 1
+%% Set up counters for next time through this loop:
+{\advance\docollabnum by1
+  \expandafter\ifx\csname
+  specificCollabLimit\the\docollabnum\endcsname\relax
+ \else
+   \global\AuthorCollaborationLimit=\csname
+   specificCollabLimit\the\docollabnum\endcsname 
+  \fi
+%
+\expandafter\ifx\csname
+CollabTotalAuthors\the\docollabnum\endcsname\relax
+\else
+\global\tempauthornumber=\csname
+CollabTotalAuthors\the\docollabnum\endcsname
+\fi}
+\fi %% ends test to see if it is time to use collaboration name
+\fi %% ends ifanonymous
+}%
 
 %%%
 %% set \affil to match \affiliation found in revtex, since authors are accustomed to using \affil{}
@@ -6282,8 +6722,10 @@ needed. It will not do anything.^^J Please use
 \newif\iffirstaffil
 \firstaffiltrue
 
-%% 
+\newcount\affilnum
+%% +++!
 \def\@affil@script#1#2#3#4{%
+\ifsuppressAffiliations\else
 \iffirstaffil
 % Oct 2017
 \vskip2pt
@@ -6294,13 +6736,14 @@ needed. It will not do anything.^^J Please use
    \frontmatter@affiliationfont
    \@ifnum{\c@affil<\affil@cutoff}{}{%
 \def\one{#1}
+%%
+%%
 \ifnum\one<\largestAffilNum
 %% this makes the numbers
    \def\@thefnmark{#1}\@makefnmark\fi
 \ifnum\one=\largestAffilNum
    \def\@thefnmark{#1}\@makefnmark\fi
    }%
-% this makes the text
 \ifnum\one<\largestAffilNum
    \ignorespaces#3%
 \fi
@@ -6311,7 +6754,9 @@ needed. It will not do anything.^^J Please use
    \par
   \endgroup
  }%
-}%
+\fi}%
+
+
 
 \newif\ifnobreakafterkeywords
 \def\NoNewPageAfterKeywords{\global\nobreakafterkeywordstrue}
@@ -6355,6 +6800,7 @@ needed. It will not do anything.^^J Please use
 \fi
 }%
 
+
 \let\maketitle\frontmatter@maketitle
 
 \def\secondtitleblock@produce{%
@@ -6374,20 +6820,6 @@ needed. It will not do anything.^^J Please use
   }%
   \endgroup
 }%
-
-
-\def\allauthors{%% this conditional keeps \allauthors from turning on
-%%                 unless \AuthorCollaborationLimit is used:
-\ifnumlines\nolinenumbers\fi
-\onecolumngrid
-\clearpage
-\AuthorCollaborationLimit=10000
-%\largestAffilNum=10000 <<== not needed
-{\vskip6pt\vskip1sp\centerline{\large\bf All Authors and
-Affiliations\vrule depth 18pt width0pt}\nobreak
-\maketitle
-}}
-\let\AllAuthors\allauthors
 
 %% no club or widow lines
 \widowpenalty=10000
@@ -6413,37 +6845,106 @@ Affiliations\vrule depth 18pt width0pt}\nobreak
 \def\figurename{Figure}
 \def\tablename{Table}
 \def\fnum@figure{{\bf\figurename~\thefigure}}
-\def\fnum@table{{\bf\tablename~\thetable}}
+\def\fnum@table{{\bf\tablename~\ifappletter\thesection\fi\thetable}}
+
 
 \def\tempfootmark#1{}
 
 \newcount\c@affilcount
 
- \renewcommand*\altaffiliation[2][]{%
- \@AF@join{#1#2\ifmodern\baselineskip=14pt\fi
-}%
- }%
 
-\def\correspondingauthor#1{{
+\renewcommand*\altaffiliation[2][]{%
+\@AF@join{#1#2\ifmodern\baselineskip=14pt\fi
+\if@two@col\hsize=.5\textwidth
+\advance\hsize by -18pt
+\fi}%
+}%
+
+\def\correspondingauthor#1{{\ifanonymous
+\else
 \renewcommand\thefootnote{\hskip-12pt}
 \footnote{Corresponding author: #1\ifmodern\vrule depth 5pt
-width 0pt\relax\fi}}}
+width 0pt\relax\fi}\fi}}
 
 \let\saveemail\email
-\def\email#1{{\let\ltx@footmark\tempfootmark
+\def\email#1{\ifanonymous
+\else{\let\ltx@footmark\tempfootmark
 \saveemail{}}
 {\renewcommand\thefootnote{\hskip-12.1pt}
 \footnote{\href{mailto: #1}{#1}\ifmodern\vrule depth 7pt width
-0pt\relax\else\ifmanu\vskip-4pt\else\vrule depth 7pt width 0pt\fi\fi}}}
+0pt\relax\else\ifmanu\vskip-4pt\else\vrule depth 7pt width
+0pt\fi\fi}}\fi}
 
-\def\nocollaboration{%
-\collaboration{\vbox to 0pt{\vss ---\vskip2pt}}
+\def\nocollaboration#1{%
+\collaboration{#1}{\vbox to
+0pt{\vss\centerline{---}\vskip2pt}}
 }
+
+%% May 19
+%% \AuthorsAndCollaboration changed to \FullCollaborationID 
+%% June 6 \FullCollaborationID changed to \xcollaboration{}{}
+%% june 7 \collaboration changed to \xcollaboration; fullcollaborationid changed to \collaboration
+
+%% here just in case we need it in the future...
+\def\xcollaboration#1#2{
+\global\advance\allentries by 1
+\expandafter\def\csname
+currCollabLimit\the\allentries\endcsname{#1}
+\@author@def{\@booleantrue
+\collaboration@sw}{#2}
+}
+
+\let\savelistand\@listand
+\newcount\numauthors
+\newcount\collabnum
+\newbox\collabnamebox
+\newif\iffirstcollab
+\global\firstcollabtrue
+
+\newif\ifcollaborationon
+\def\collaboration#1#2{\global\collaborationontrue
+\global\advance\collabnum by 1
+\iffirstcollab\global\firstcollabfalse
+\expandafter\xdef\csname currCollabLimit0\endcsname{#1}
+\fi
+%% make this def so that we can use it when we want in doauthor:
+\expandafter\gdef\csname specificCollabLimit\the\collabnum\endcsname{#1} 
+%% This allows us access the number of authors per collaboration:
+\expandafter\xdef\csname
+CollabTotalAuthors\the\collabnum\endcsname{\the\entriesinthiscollab} 
+\global\entriesinthiscollab=0
+%%
+\global\advance\allentries by 1
+%% 
+%% we should have only one of these with this number; this used to say when
+%% use specificCollabLimit:
+\expandafter\gdef\csname currCollabLimit\the\allentries\endcsname{#1}
+%% we should have only one of these with this number
+\expandafter\gdef\csname
+currCollabName\the\allentries\endcsname{%\ifnum#1>0
+%\sc And the\vskip4pt\fi
+#2}
+%%
+\let\doEtAl\relax
+\@author@def{\@booleanfalse
+\collaboration@sw}{}
+}
+
+
+\def\and{
+\centerline{\vbox {\vrule height 12pt width0pt and\vskip2pt}}
+}
+
+%\def\andthe{%
+%\collaboration{\vbox {\vrule height 12pt width0pt and
+%the\vskip2pt}}\vskip4pt
+%}
 
 %% gets rid of () around collaboration
 \def\@collaboration@present#1#2#3#4{%
 \par
  \begingroup
+\vskip3pt
 \iflongauthor\vskip-4pt\ifmodern\vskip-6pt\fi\fi
   \frontmatter@collaboration@above
   \@affilID@def{}%
@@ -6458,11 +6959,12 @@ width 0pt\relax\fi}}}
 \iflongauthor 
 \else\vskip8pt\fi
  \set@listcomma@list#1%
+\vskip1pt %% was \vskip9pt
 }%
 
 
 %%% These lines were commented out until a fix could be applied that
-%%% addresses the underlying issues. The problme is that on Linux systems
+%%% addresses the underlying issues. The problem is that on Linux systems
 %%% you can not write a "hidden" .bib file. There is no issue with this
 %%% on Mac OS X nor Windows.
 %%% get rid of \jobname Notes being sent to .aux file:
@@ -6502,6 +7004,7 @@ width 0pt\relax\fi}}}
 \,     \unskip\unskip
      \par
     \endgroup
+%%
     \begingroup
      \frontmatter@above@affiliation@script
      \let\AFF@opr \@affil@script
@@ -6519,6 +7022,7 @@ width 0pt\relax\fi}}}
 
 \newif\iffirstaffil
 \firstaffiltrue
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% These commands were in aastex earlier; I redefined.
 \def\tighten{\global\tightentrue\normalsize}
@@ -6573,10 +7077,205 @@ width 0pt\relax\fi}}}
 
 \def\mdash{---}
 
+\newif\ifcenterwidetable
+%% these two definitions are the same, but it might
+%% be convenient to have both
+\def\centerwidetable{\global\centerwidetabletrue}
+
+
+%% this doesn't seem to be documented, assume we don't need it:
+%\def\centernarrowtable{\global\centerwidetablefalse}
+
+%% default, center within width of text on both sides
+ \def\LT@LR@c{\LTleft=0pt plus1fill 
+  \LTright\LTleft}%
+
+\def\widetable{\def\LT@LR@c{\LTleft=0pt minus1fill 
+  \let\LTright\LTleft}}
+
+\newif\ifreturntotwocol
+
+
+%%%%%%%%%
+%% to help with graceful linebreaks in two column text:
+  \tolerance 9999%
+%% sloppy defines emergencystretch to be 3 em, this is a bit
+%% more conservative:
+  \emergencystretch 1em 
+  \hfuzz .5\p@
+
+%%%%%%%%%
+%% Nominal Conversion Constants
+
+%%  \boldmath inside the \hbox ??
+\def\nomSolarEffTemp{\leavevmode\hbox{\boldmath$\mathcal{T}^{\rm N}_{\mathrm{eff}\odot}$}}
+\def\nomTerrEqRadius{\leavevmode\hbox{\boldmath$\mathcal{R}^{\rm N}_{E\mathrm e}$}}
+\def\nomTerrPolarRadius{\leavevmode\hbox{\boldmath$\mathcal{R}^{\rm N}_{E\mathrm p}$}}
+\def\nomJovianEqRadius{\leavevmode\hbox{\boldmath$\mathcal{R}^{\rm
+N}_{J\mathrm e}$}}
+ \def\nomJovianPolarRadius{\leavevmode\hbox{\boldmath$\mathcal{R}^{\rm
+ N}_{J\mathrm p}$}}
+ \def\nomTerrMass{\leavevmode\hbox{\boldmath$(\mathcal{GM})^{\rm N}_{\mathrm E}$}}
+ \def\nomJovianMass{\leavevmode\hbox{\boldmath$(\mathcal{GM})^{\rm N}_{\mathrm J}$}}
+ \def\Qnom{\leavevmode\hbox{\boldmath$\mathcal{Q}^{\rm N}_{\odot}$}}
+\let\Qn\Qnom
+
+%% Generic commands that can be given an argument:
+\def\nom#1{\leavevmode\hbox{\boldmath$\mathcal{#1}^{\rm N}_{\odot}$}}
+\def\Eenom#1{\leavevmode\hbox{\boldmath$\mathcal{#1}^{\rm N}_{Ee}$}}
+\def\Epnom#1{\leavevmode\hbox{\boldmath$\mathcal{#1}^{\rm N}_{Ep}$}}
+\def\Jenom#1{\leavevmode\hbox{\boldmath$\mathcal{#1}^{\rm N}_{Je}$}}
+\def\Jpnom#1{\leavevmode\hbox{\boldmath$\mathcal{#1}^{\rm N}_{Jp}$}}
+
+%%%%%%%%%%%%%%%%
+%% Ability to have tables, equations, figures in appendix start from 1, and use appendix section letter.
+
+\newif\ifappletter
+\def\apptablenumbers{\global\applettertrue
+\setcounter{table}{0}
+\setcounter{figure}{0}
+\setcounter{equation}{0}
+\def\thetable{\thesection\the\c@table}%
+\def\fnum@table{{\bf\tablename~\thetable}}%
+\def\thefigure{\thesection\the\c@figure}%
+\def\fnum@figure{{\bf\figurename~\thefigure}}%
+}%
+
+%%% easier to remember than \apptablenumbers
+\let\restartappendixnumbering\apptablenumbers
+
+\def\resetapptablenumbers{\global\c@table=0
+\global\c@figure=0
+\global\c@equation=0
+\def\thetable{\thesection\the\c@table}
+\def\fnum@table{{\bf\tablename~\thetable}}%
+\def\thefigure{\thesection\the\c@figure}
+\def\fnum@figure{{\bf\figurename~\thefigure}}%
+}
+
+%% aastex63
+\newif\ifallauthors
+\def\allauthors{\global\allauthorstrue
+\let\doauthor\doAllauthors
+\ifanonymous
+\vskip6pt\vskip1sp\centerline{\large\bf All Authors and
+Affiliations\vrule depth 18pt width0pt}\nobreak
+\centerline{Anonymous author(s)}
+\else
+\ifnumlines\nolinenumbers\fi
+\onecolumngrid
+\clearpage
+{\vskip6pt\vskip1sp\centerline{\large\bf All Authors and
+Affiliations\vrule depth 18pt width0pt}\nobreak
+\global\docollabnum=0
+\global\totalentries=0
+\global\countauthors=0
+\maketitle
+}\fi}
+
+%% AASTeX62
+\def\oldallauthors{%% this conditional keeps \allauthors from turning on
+%%                 unless \AuthorCollaborationLimit is used:
+\ifnumlines\nolinenumbers\fi
+\onecolumngrid
+\clearpage
+\AuthorCollaborationLimit=10000
+%\largestAffilNum=10000 <<== not needed
+{\vskip6pt\vskip1sp\centerline{\large\bf All Authors and
+Affiliations\vrule depth 18pt width0pt}\nobreak
+\maketitle
+}}
+\let\AllAuthors\allauthors
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% New interactive command:
+
+\def\xlc{timeseries}
+\def\xjs{js}
+\def\xanimation{animation}
+
+\newif\ifcorrectentries
+\def\interactive#1#2{\global\correctentriesfalse\def\checkone{#1}
+\ifx\checkone\xlc\correctentriestrue\fi
+\ifx\checkone\xjs\correctentriestrue\fi
+\ifx\checkone\xanimation \correctentriestrue\fi
+\ifcorrectentries
+\else\hrule height1pt\vskip12pt\bf ERROR: Your choices for the first argument for
+{\tt\string\interactive} are timeseries, js, or animation.\\[6pt] Please choose one
+of these terms.\vskip12pt \fi
+%%%
+\def\checktwo{#2}
+\ifx\checktwo\empty \vskip12pt \bf ERROR: The command {\tt\string\interactive} needs
+two arguments, with the second argument for the graphics file or files
+needed.\vskip12pt\hrule height1pt \else\correctentriestrue\fi
+\setbox0=\vbox\bgroup}
+
+\def\endinteractive{\egroup
+\ifcorrectentries\highlightfigure{\vskip-6pt\vbox{\unvbox0}
+\vskip-12pt}\fi}
+
+%%%% For cases in which footnotes are called in full width environment
+%%   but are used in two cols. This keeps them from overwriting the
+%%   second column:
+
+\let\savefootnote\footnote
+\def\onecolfootnote#1{\savefootnote{\hsize=.5\textwidth\advance\hsize
+by-18pt\relax#1}}
+
+\def\onecolumnfootnotes{\let\footnote\onecolfootnote}
+
+\newdimen\movetableright
+
+\newif\ifsuppressAffiliations
+\def\suppressAffiliations{\global\suppressAffiliationstrue}
+
 
 \endinput
 
+
 %% Change Log
+============================
+June 8, 2019
+Changed \author and \collaboration macros.
+Collaboration now takes two arguments:
+#1= number of authors to be listed before the
+name of the collaboration; #2 = name of the collaboration
+
+\nocollaboration{} has one argument, 
+#1= the number of authors above it that we want to print on the title page.
+
+June 6, 2019
+
+\acknowledgments does not use \begin{}...\end{} form,
+now just \acknowledgments command. Acknowledgments text
+ends with \par, so if author wants more than one paragraph
+in acknowledgment he/she should surround text with curly
+bracket:
+
+\acknowledgments
+text...
+
+or
+
+\acknowledgments
+{text...
+
+more text...}
+
+------
+
+
+============================
+June 3, 2019
+\let\footnote\onecolfootnote on page where references start, but
+before footnotes are entered,
+will allow footnotes to break in the right place (one column's width).
+
+============================
+May 15, 2019
+\centerwidetable is now \movetableover at Greg's suggestion.
+
 ============================
 Nov 27, 2017
 
@@ -6829,11 +7528,6 @@ Deleted recent definition of \appendix, returned to earlier version
 with additions.
 
 ================
-
-
-
-
-
 
 
 

--- a/authors.tex
+++ b/authors.tex
@@ -1,4 +1,5 @@
-\newcommand{\goddard}{NASA Goddard Space Flight Center, Greenbelt, MD, USA}
+\newcommand{\goddard}{NASA Goddard Space Flight Center, Greenbelt, MD 20771, USA}
+\newcommand{\catholic}{The Catholic University of America, Washington, DC 20664, USA}
 \newcommand{\kharagpur}{Indian Institute of Technology Kharagpur, India}
 \newcommand{\Shibpur}{Indian Institute of Engineering Science and Technology Shibpur, India}
 
@@ -16,58 +17,60 @@
 \affiliation{Bay Area Environmental Research Institute, Moffett Field, CA 94952, USA}
 
 \author[0000-0002-5662-9604]{Monica G. Bobra}
+\altaffiliation{SunPy Board Member}
 \affiliation{W.W. Hansen Experimental Physics Laboratory, Stanford University, Stanford, CA 94305, USA}
-\affiliation{SunPy Board Member}
 
 \author[0000-0001-6127-795X]{Steven D. Christe}
+\altaffiliation{SunPy Board Member}
 \affiliation{\goddard}
-\affiliation{SunPy Board Member}
 
 \author{Nabil Freij}
-\affiliation{SunPy Deputy Lead Developer}
+\altaffiliation{SunPy Deputy Lead Developer}
 
 \author[0000-0002-6835-2390]{Laura Hayes}
 \affiliation{\goddard}
 
 \author[0000-0002-2019-8881]{Jack Ireland}
+\altaffiliation{SunPy Communications Officer, SunPy Board Member}
 \affiliation{\goddard}
-\affiliation{SunPy Communications Officer}
-\affiliation{SunPy Board Member}
 
 \author[0000-0003-4217-4642]{Stuart Mumford}
-\affiliation{DKIST, National Solar Observatory, USA}
-\affiliation{Aperio Software, UK}
-\affiliation{SunPy Lead Developer}
-\affiliation{SunPy Board Member}
+\altaffiliation{SunPy Lead Developer, SunPy Board Member}
+\affiliation{SP$^2$RC, School of Mathematics and Statistics, The University of Sheffield, UK}
+\affiliation{Aperio Software, Leeds, LS6 3HN, UK}
 
 \author{David Perez-Suarez}
+\altaffiliation{SunPy Summer of Code Administrator, SunPy Board Member}
 \affiliation{University College London, Gower Street, London, UK}
-\affiliation{SunPy Summer of Code Administrator}
-\affiliation{SunPy Board Member}
 
 \author[0000-0001-8661-3825]{Daniel F.\ Ryan}
 \affiliation{\goddard}
-\affiliation{Catholic University of America, Washington, DC, USA}
+\affiliation{\catholic}
 
 \author[0000-0001-6874-2594]{Albert Y. Shih}
 \affiliation{\goddard}
 
-\collaboration{(Primary Paper Contributors)}
+\collaboration{1000}{(Primary Paper Contributors)}
+
 
 % Below add contributors to the Sunpy project
 % this list is ordered alphabetically
 \author[0000-0002-7068-2866]{Prateek Chanda}
 \affiliation{\Shibpur}
 
+\author[0000-0002-1361-5712]{Kolja Glogowski}
+\affiliation{Kiepenheuer-Institut f\"{u}r Sonnenphysik, Freiburg, Germany}
+\affiliation{eScience Department, Computing Center, University of Freiburg, Freiburg, Germany}
+
 \author[0000-0001-8944-4705]{Russell Hewett}
+\altaffiliation{SunPy Board Member}
 \affiliation{Department of Mathematics, Virginia Tech, Blacksburg, VA 24061-0123}
-\affiliation{SunPy Board Member}
 
 \author[0000-0003-0787-9559]{V. Keith Hughitt}
-\affiliation{Center for Cancer Research, National Cancer Institute, Bethesda, MD, USA}
+\affiliation{Center for Cancer Research, National Cancer Institute, Bethesda, MD 20892-9760, USA}
 
 \author{Andrew Hill}
-\affiliation{Oklahoma Baptist University}
+\affiliation{Oklahoma Baptist University, Shawnee, OK 74804, USA}
 
 \author[0000-0003-3301-1016]{Kaustubh Hiware}
 \affiliation{\kharagpur}
@@ -77,7 +80,7 @@
 
 \author[0000-0001-9874-1429]{Michael S. F. Kirk}
 \affiliation{\goddard}
-\affiliation{Catholic University of America, Washington, DC, USA}
+\affiliation{\catholic}
 
 \author{Sudarshan Konge}
 \affiliation{Microsoft India Development Center, India}
@@ -85,42 +88,40 @@
 \author[0000-0002-3783-5509]{James Paul Mason}
 \affiliation{\goddard}
 
+% This is not really an affiliation...
 \author{Asish Panda}
-\affiliation{GSOC 2014}
+\affiliation{Google Summer of Code 2014}
 
 \author[0000-0002-1063-9129]{Jongyeob Park}
 \affiliation{Space Science Division, Korea Astronomy and Space Science Institute, Daejeon 34055, South Korea}
 
 \author[0000-0003-4747-4329]{Tiago M. D. Pereira}
-\affiliation{Institute of Theoretical Astrophysics, University of Oslo, P.O. Box 1029 Blindern, NO-0315 Oslo, Norway}
-\affiliation{Rosseland Centre for Solar Physics, University of Oslo, P.O. Box 1029 Blindern, NO-0315 Oslo, Norway}
+\affiliation{Institute of Theoretical Astrophysics, University of Oslo, Oslo, Norway}
+\affiliation{Rosseland Centre for Solar Physics, University of Oslo, Oslo, Norway}
 
 \author{Kevin Reardon}
-\affiliation{An affiliation}
-\affiliation{SunPy Board Member}
+\altaffiliation{SunPy Board Member}
+\affiliation{National Solar Observatory, Boulder, CO 80303, USA}
 
 \author{Sabrina Savage}
-\affiliation{NASA Marshall Space Flight Center, Huntsville, AL, USA}
-\affiliation{SunPy Board Member}
+\altaffiliation{SunPy Board Member}
+\affiliation{NASA Marshall Space Flight Center, Huntsville, AL 35812, USA}
 
 % may not want to be author, waiting for confirmation
 %\author{Kalpesh Krishna}
 %\affiliation{University of Massachusetts Amherst}
 
 \author[0000-0002-3713-6337]{Brigitta M.\ Sip\H{o}cz}
-\affiliation{DIRAC Institute, Department of Astronomy, University of Washington, 3910 15th Avenue NE, Seattle, WA 98195, USA}
+\affiliation{DIRAC Institute, Department of Astronomy, University of Washington, Seattle, WA 98195, USA}
 
 \author[0000-0002-1365-1908]{David Stansby}
-\affiliation{Imperial College London, UK}
-
+\affiliation{Department of Physics, Imperial College London, London, SW7 2AZ, UK}
 
 \author{Yash Jain}
 \affiliation{\kharagpur}
 
-
 \author{Garrison Taylor}
-\affiliation{Harvard-Smithsonian Center for Astrophysics, Cambridge, MA, USA}
-
+\affiliation{Harvard-Smithsonian Center for Astrophysics, Cambridge, MA 02138, USA}
 
 \author{Tannmay Yadav}
 \affiliation{\kharagpur}
@@ -128,7 +129,7 @@
 \author[0000-0003-3552-8799]{Rajul}
 \affiliation{\kharagpur}
 
-\collaboration{(Sunpy Contributors)}
+\collaboration{1000}{(Sunpy Contributors)}
 
 \correspondingauthor{Steven Christe}
 \email{steven.christe@nasa.gov}

--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,4 @@
-\documentclass{aastex62}
+\documentclass{aastex63}
 \usepackage[utf8]{inputenc}
 \usepackage{natbib}
 \usepackage{listings}


### PR DESCRIPTION
Fixes #107, #95 

I've also used the `\altaffiliation` command to denote the different roles (e.g. board member, lead developer) rather the usual numerical affiliation marker. This helps to delineate these contributions from just normal institutional affiliations.