### PR TITLE
Minor fixes to the introduction and a normalization pass for abbreviations

### DIFF
--- a/sections/1-introduction.tex
+++ b/sections/1-introduction.tex
@@ -11,14 +11,14 @@ Second, IDL includes many libraries that support scientific data visualization a
 Finally, the solar community benefitted from functionality developed by the astronomy community (specifically, the IDL Astronomy User's Library).
 Since then, significant functionality has been developed by the solar community and freely distributed as the SolarSoftWare library \citep{Freeland:1998we}.
 
-Officially founded in March of 2014, the goal of the \sunpyproj is to provide the core functionality needed for solar data analysis in \python\footnote{\url{https://www.python.org/}}, a high-level interpreted  programming language, and facilitate a new transition to bring significant and new benefits to the solar community.
+Officially founded in March 2014, the goal of the \sunpyproj is to provide the core functionality needed for solar data analysis in \python\footnote{\url{https://www.python.org/}}, a high-level interpreted programming language, and facilitate a new transition to bring significant and new benefits to the solar community.
 The \sunpyproj develops and maintains a community-led, free, and open-source\footnote{\url{https://opensource.org/osd}} core \python package (\sunpypkg), supports an ecosystem of affiliated packages (see \autoref{sec:affil_package}) consistent with best practices \citep{Wilson:2014cka}, and engages with the community through mailing lists, chat rooms, tutorials, summer programs, and mentorship.
-The \sunpyproj shares these goals with the Astropy Project\footnote{\url{https://www.astropy.org}}, which develops the \astropypkg core package \citep{astropy2018} for the astrophysics community.
+The \sunpyproj has similar goals to the Astropy project\footnote{\url{https://www.astropy.org}}, which develops the \astropypkg core package \citep{astropy2018} for the astrophysics community.
 
 The choice of \python was motivated by several different factors.
 The scientific \python ecosystem provides a rich and mature ecosystem of packages for performing scientific analysis and computation.
-It is supported by foundational packages for manipulating tabular \citep[\pandas,][]{pandas} and multi-dimensional array\citep[\numpy,][]{numpy} data, general purpose scientific computing \citep[\scipy,][]{scipy}, and publication-quality 2D plotting \citep[\matplotlib,][]{matplotlib}\footnote{According to the The 2018 Python Developers Survey \url{https://www.jetbrains.com/research/python-developers-survey-2018/}, data analysis is the primary use for \python thanks to the broad functionality provided by these foundational packages.}
-These core packages form the backbone of hundreds of additional scientific \python packages, such as \astropypkg for functionality and tools specific to astronomy, scikit-learn for machine learning and data mining \citep{pedregosa11}, and Dask for parallel and distributed computing \citep{rocklin15}.
+It is supported by foundational packages for manipulating tabular \citep[\pandaspkg,][]{pandas} and multi-dimensional array \citep[\numpypkg,][]{numpy} data, general purpose scientific computing \citep[\scipypkg,][]{scipy}, and publication-quality 2D plotting \citep[\matplotlibpkg,][]{matplotlib}\footnote{According to the The 2018 Python Developers Survey \url{https://www.jetbrains.com/research/python-developers-survey-2018/}, data analysis is the primary use for \python thanks to the broad functionality provided by these foundational packages.}
+These core packages form the backbone of hundreds of additional scientific \python packages, such as \astropypkg for functionality and tools specific to astronomy, \package{scikit-learn} for machine learning and data mining \citep{pedregosa11}, and \package{dask} for parallel and distributed computing \citep{rocklin15}.
 Interoperability between all these packages enables interdisciplinary analysis across traditional fields of study including solar physics, space physics, and astrophysics.
 
 The \python programming language is freely-available, meaning users are not bound by restrictive and costly proprietary licenses.
@@ -33,9 +33,9 @@ This approach, combined with strict version control, allows scientists to create
 
 For all these reasons, the scientific \python ecosystem played a key role in recent major scientific discoveries, such as the first detection of a gravitational wave \citep{ligo_scientific_collaboration_and_virgo_collaboration_observation_2016} and the first image of a black hole \citep{collaboration_first_2019}.
 The data and code used to generate these results are openly available, allowing anyone to reproduce them.
-Because the solar community is relatively small\footnote{For reference, out of the $\sim$9,500 members of the American Astronomy Society, approximately 500 are members of the society's Solar Physics Division.} in relation to other scientific communities, it stands to benefit immensely by adopting the \python scientific stack to solve increasingly difficult scientific challenges and produce world-class science.
+Because the solar community is relatively small\footnote{For reference, out of the $\sim$9,500 members of the American Astronomy Society, approximately 500 are members of the society's Solar Physics Division.} in relation to other scientific communities, it will benefit immensely by leveraging the \python scientific ecosystem to solve increasingly difficult scientific challenges and produce world-class science.
 
-This paper describes the first stable release (version 1.0) of the (\sunpypkg) core package.
+This paper describes the first stable release (version 1.0) of the \sunpypkg core package.
 A previous paper describes version 0.5 \citep{Community:2015cy}.
 This article is not meant to replace the \sunpypkg documentation but provides an overview of the organization and highlights important functionality.
 The full text of the paper, including all of the code to produce the figures, is available in a \github repository\footnote{\url{https://github.com/sunpy/sunpy-1.0-paper}}.

--- a/sections/2-project_proposals.tex
+++ b/sections/2-project_proposals.tex
@@ -10,13 +10,11 @@
     \startdata
     AIA & Atmospheric Imaging Assembly \\
     DRMS & Data Record Management System \\
-    FITS & Flexible Image Transport System \\
     GOES & \textit{Geostationary Operational Environmental Satellite} \\
-    HEK & Heliophysics Event Knowledgebase \\
     HAE & Heliocentric Aries Ecliptic \\
-    HCC & Heliocentric Cartesian \\
     HCRS & Heliocentric Celestial Reference System \\
     HEEQ & Heliocentric Earth Equatorial \\
+    HEK & Heliophysics Event Knowledgebase \\
     HGC & Heliographic Carrington \\
     HGS & Heliographic Stonyhurst \\
     HPC & Helioprojective Cartesian \\
@@ -29,10 +27,9 @@
     NOAA & National Oceanic and Atmospheric Administration \\
     PEP & Python Enhancement Proposal \\
     SDO & \textit{Solar Dynamics Observatory} \\
+    SJI & Slit Jaw Imager \\
     SOHO & \textit{Solar and Heliospheric Observatory} \\
     SEP & SunPy Enhancement Proposal \\
-    SPoCA & Spatial Possibilistic Clustering Algorithm \\
-    TAI & International Atomic Time \\
     UTC & Coordinated Universal Time \\
     VSO & Virtual Solar Observatory \\
     WCS & World Coordinate System \\

--- a/sections/5-modules.tex
+++ b/sections/5-modules.tex
@@ -12,7 +12,7 @@ This section provides an overview of the \Timeseries and \Map data types.
 \subsubsection{\Timeseries}
 \label{sec:timeseries}
 Many observations in the field of solar physics consist of spatially-integrated measurements as a function of time.
-For example, the X-ray Sensor (XRS) instrument aboard the Geostationary Operational Environmental Satellite (GOES), which is used as the classification standard for solar flares, continuously measures the disk-integrated X-ray flux as a function of time in two broadband channels.
+For example, the X-Ray Sensor (XRS) instrument aboard the Geostationary Operational Environmental Satellite (GOES), which is used as the classification standard for solar flares, continuously measures the disk-integrated X-ray flux as a function of time in two broadband channels.
 The \Timeseries class aims to accommodate such solar time series data.
 
 \Timeseries allows users to load time series data from a variety of solar instruments with appropriate units and time scales (see \autoref{sec:units}).
@@ -41,7 +41,7 @@ An example of a \Timeseries created from GOES XRS observations of a solar flare 
 \textbf{Supported by \Timeseries}& \textbf{Instrument reference}\\
 \hline
 \hline
-GOES XRS & \citet{garcia94, hanser96} \\
+\textit{Geostationary Operational Environmental Satellite} (GOES) X-Ray Sensor (XRS) & \citet{garcia94, hanser96} \\
 \hline
 \textit{Fermi} Gamma-ray Burst Monitor (GBM) &  \citet{meegan2009fermi} \\
 \hline
@@ -49,7 +49,7 @@ GOES XRS & \citet{garcia94, hanser96} \\
 \hline
 \textit{PRoject for Onboard Autonomy} (PROBA2) Large Yield Radiometer (LYRA) & \citet{dominique2013lyra} \\
 \hline
-SDO EUV Variability Experiment (EVE) & \citet{woods2010extreme}  \\
+\textit{Solar Dynamics Observatory} (SDO) EUV Variability Experiment (EVE) & \citet{woods2010extreme}  \\
 \hline
 \textit{Reuven Ramaty High Energy Solar Spectroscopic Imager} (RHESSI) & \citet{lin2002reuven} \\
 \hline
@@ -61,21 +61,21 @@ SDO EUV Variability Experiment (EVE) & \citet{woods2010extreme}  \\
 \hline
 \textit{Hinode} X-Ray Telescope (XRT) & \citet{golub2008x}  \\
 \hline
-IRIS SJI & \citet{DePontieu2014}  \\
+\textit{Interface Region Imaging Spectrograph} (IRIS) Slit Jaw Imager (SJI) & \citet{DePontieu2014}  \\
 \hline
 PROBA2 Sun Watcher using Active Pixel System detector and Image Processing (SWAP) & \citet{seaton2013swap} \\
 \hline
 RHESSI & \citet{lin2002reuven} \\
 \hline
-SOHO Extreme ultraviolet Imaging Telescope (EIT) & \citet{delaboudiniere1995eit}\\
+\textit{Solar and Heliospheric Observatory} (SOHO) Extreme ultraviolet Imaging Telescope (EIT) & \citet{delaboudiniere1995eit}\\
 \hline
 SOHO Large Angle Spectroscopic COronagraph (LASCO) & \citet{brueckner1995large} \\
 \hline
-SOHO MDI & \citet{scherrer1995solar}\\
+SOHO Michelson Doppler Imager (MDI) & \citet{scherrer1995solar}\\
 \hline
-SDO AIA & \citet{lemen2012} \\
+SDO Atmospheric Imaging Assembly (AIA) & \citet{lemen2012} \\
 \hline
-SDO HMI & \citet{schou12}  \\
+SDO Helioseismic and Magnetic Imager (HMI) & \citet{schou12}  \\
 \hline
 \textit{Solar TErrestrial RElations Observatory} (STEREO) Extreme Ultraviolet Imager (EUVI), COronagraph 1 and 2 (COR1/2) for both STEREO A and B & \citet{howard2008sun} \\
 \hline


### PR DESCRIPTION
- Minor fixes to the introduction
- Normalization pass for abbreviations (see https://github.com/sunpy/sunpy-1.0-paper/pull/149#issuecomment-522408736).  To be listed in the table, an abbreviation needs to be used at least twice in the text, and the Map/TimeSeries table is ignored in that counting, as well as the parenthetical following "HTTP websites" in the `Fido` section.